### PR TITLE
Fixed more PDB parsing, and reformatted Fluctuation Window

### DIFF
--- a/dist/editing/editing.js
+++ b/dist/editing/editing.js
@@ -205,7 +205,7 @@ function deleteNetworkWrapper(nid) {
 }
 function fillEdgesWrapper(nid, edgecase) {
     // Easy expansion for other edge methods
-    if (networks.length == 0) {
+    if (networks.length == 0 || nid < 0) {
         notify('No Networks Found, Please Create Network');
     }
     else {
@@ -219,6 +219,9 @@ function fillEdgesWrapper(nid, edgecase) {
                 else {
                     net.edgesByCutoff(cutoff);
                 }
+                break;
+            case 1:
+                net.edgesMWCENM();
         }
     }
 }

--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -83,7 +83,7 @@ function handleFiles(files) {
             readPdbFile(pdbfile);
             return;
         }
-        else if (ext === ".hb") {
+        else if (ext === "hb") {
             hbondfile = files[i];
             readHBondFile(hbondfile);
             return;
@@ -628,6 +628,39 @@ function readParFile(file) {
     };
     reader.readAsText(file);
 }
+// reads hydrogen bonding file generated with Chimera
+// hbondinfo is then stored in the pdbfiledatasets
+function readHBondFile(file) {
+    let reader = new FileReader();
+    let pdbInfoIndx = pdbFileInfo.length - 1;
+    if (pdbInfoIndx == -1) {
+        notify("Please Load PDB file to associate H-Bond file with");
+        return;
+    }
+    reader.onload = () => {
+        let lines = reader.result.split(/[\n]+/g);
+        const size = lines.length;
+        let hbonds = [];
+        //process hbonds
+        for (let i = 0; i < size - 1; i++) {
+            if (recongizedProteinResidues.indexOf(lines[i].substring(0, 3).trim()) != -1) { //check that its a protein residue
+                // trims all split items then removes the empty strings
+                let l = lines[i].split(" ").map(function (item) { return item.trim(); }).filter(n => n);
+                //extract values
+                const pos1 = l[1].split("."), atm1 = l[2], id2 = l[3], pos2 = l[4].split("."), atm2 = l[5], dist = parseFloat(l[8]);
+                if (recongizedProteinResidues.indexOf(id2) != -1) { //bonded to another protein residue
+                    // Chain Identifier, residue number
+                    let pdbinds1 = [pos1[1], parseInt(pos1[0])];
+                    let pdbinds2 = [pos2[1], parseInt(pos2[0])];
+                    let hbond = [pdbinds1, pdbinds2];
+                    hbonds.push(hbond);
+                }
+            }
+        }
+        pdbFileInfo[pdbInfoIndx].hydrogenBonds = hbonds;
+    };
+    reader.readAsText(file);
+}
 // function addANMToScene(anm: ANM) {
 //     anm.geometry = instancedConnector.clone();
 //
@@ -865,7 +898,14 @@ function prep_pdb(pdblines) {
     }
     return { "initlist": initList, "dsbonds": dsbonds };
 }
-//
+// Members of the Recongized arrays cannot have overlapping Members
+const recongizedProteinResidues = ["ALA", "ARG", "ASN", "ASP", "CYS", "CYX", "GLN",
+    "GLU", "GLY", "HIS", "ILE", "MET", "LEU", "LYS", "PHE", "PRO", "SER",
+    "THR", "TRP", "TYR", "VAL", "SEC", "PYL", "ASX", "GLX", "UNK"];
+const recongizedDNAResidues = ["DG", "DT", "DA", "DC", "DU", "DI", "DN"];
+const recongizedDNAStrandEnds = ["DG3", "DG5", "DT3", "DT5", "DA3", "DA3", "DC3", "DC5"];
+const recongizedRNAResidues = ["A", "C", "G", "I", "U", "N"];
+const recongizedRNAStrandEnds = ["A3", "A5", "C3", "C5", "G3", "G5", "U3", "U5"];
 function readPdbFile(file) {
     let reader = new FileReader();
     reader.onload = () => {
@@ -875,7 +915,7 @@ function readPdbFile(file) {
         let dsbonds = ret["dsbonds"];
         let uniqatoms = [];
         let uniqresidues = []; // individual residue data parsed from Atomic Info
-        let uniqchains = [];
+        let uniqchains = []; // individual chain data parsed from Atomic Info
         // bookkeeping
         let label = "pdb";
         // Search Just the Header for PDB code ex. (1BU4), label used for graph datasets
@@ -900,9 +940,59 @@ function readPdbFile(file) {
         let na = new pdbatom();
         let nr = new pdbresidue();
         let nc = new pdbchain();
-        const recongizedProteinResidues = ["ALA", "ARG", "ASN", "ASP", "CYS", "GLN",
-            "GLU", "GLY", "HIS", "ILE", "MET", "LEU", "LYS", "PHE", "PRO", "SER",
-            "THR", "TRP", "TYR", "VAL", "SEC", "PYL", "ASX", "GLX", "UNK"];
+        // helper functions for calculating a1 vector of nucleotide
+        function contains(target, pattern) {
+            var value = 0;
+            pattern.forEach(function (word) {
+                value = value + target.includes(word);
+            });
+            return (value === 1);
+        }
+        // calculates a1 vector from nucleotide of Amino acid
+        let calcA1FromRes = function (firstresidueunique) {
+            if (recongizedProteinResidues.indexOf(firstresidueunique.resType) > -1) {
+                let scHAcom = new THREE.Vector3; //side chain Heavy atoms Center of Mass
+                firstresidueunique.atoms.forEach(a => {
+                    if (['N', 'C', 'O', 'H', 'CA'].indexOf(a.atomType) == -1) {
+                        scHAcom.x += a.x;
+                        scHAcom.y += a.y;
+                        scHAcom.z += a.z;
+                    }
+                });
+                // if null vector (glycine) a1 is 1, 0, 0
+                if (scHAcom.lengthSq() == 0)
+                    scHAcom.x = 1;
+                scHAcom.normalize();
+                let CA = firstresidueunique.atoms.filter(a => a.atomType == 'CA')[0];
+                if (CA) {
+                    let CApos = new THREE.Vector3(CA.x, CA.y, CA.z);
+                    return scHAcom.clone().sub(CApos).normalize(); // this is the a1 vector
+                }
+                else {
+                    notify("No CA coordinate found in Repeat Chain");
+                    return new THREE.Vector3(1, 0, 0);
+                }
+            }
+            else {
+                let pairs;
+                // Compute a1 Vector
+                if (contains(firstresidueunique.resType, ["C", "T", "U"])) {
+                    pairs = [["N3", "C6"], ["C2", "N1"], ["C4", "C5"]];
+                }
+                else {
+                    pairs = [["N1", "C4"], ["C2", "N3"], ["C6", "C5"]];
+                }
+                let a1 = new THREE.Vector3(0, 0, 0);
+                for (let i = 0; i < pairs.length; i++) {
+                    let p_atom = firstresidueunique.atoms.filter(a => a.atomType == pairs[i][0])[0];
+                    let q_atom = firstresidueunique.atoms.filter(a => a.atomType == pairs[i][1])[0];
+                    let diff = new THREE.Vector3(p_atom.x - q_atom.x, p_atom.y - q_atom.y, p_atom.z - q_atom.z);
+                    a1.add(diff);
+                }
+                a1.normalize();
+                return a1;
+            }
+        };
         let chainindx = -1;
         let loadpdbsection = function (start, end) {
             pdbpositions = [];
@@ -992,10 +1082,64 @@ function readPdbFile(file) {
             return [Amino, pdbpositions, atoms, residues, chains];
         };
         let getpdbpositions = function (start, end, Amino) {
-            // reads in pdb text and returns the positions b/t start and end linenumbers
+            // reads in pdb text and returns the positions b/t start and end linenumbers and the first residues a1 vector
             let pdbpositions = [];
+            let atoms = [];
+            let firstres = true;
+            let prevResId;
+            let a1;
             for (let j = start; j < end; j++) {
                 if (pdbLines[j].substr(0, 4) === 'ATOM') {
+                    if (firstres) {
+                        let pdbLine = pdbLines[j];
+                        na.atomType = pdbLine.substring(12, 16).trim();
+                        na.resType = pdbLine.substring(17, 20).trim();
+                        let tmp = pdbLine.substring(23, 29); // Usually the residue number
+                        //check for insertion code
+                        na.iCode = "";
+                        if (isNaN(parseInt(tmp[5]))) {
+                            na.iCode = tmp[5];
+                            na.pdbResIdent = tmp.slice(0, 5).trim();
+                        }
+                        else {
+                            na.pdbResIdent = tmp.trim();
+                        }
+                        // Convert From Angstroms to Simulation Units while we're at it
+                        na.x = parseFloat(pdbLine.substring(30, 38)) / 8.518;
+                        na.y = parseFloat(pdbLine.substring(38, 46)) / 8.518;
+                        na.z = parseFloat(pdbLine.substring(46, 54)) / 8.518;
+                        // residue type has to be correct
+                        if (atoms.length == 0)
+                            Amino = recongizedProteinResidues.indexOf(na.resType) >= 0;
+                        if (Amino) {
+                            if (na.atomType == "CA")
+                                pdbpositions.push(new THREE.Vector3(na.x, na.y, na.z));
+                        }
+                        else {
+                            if (na.atomType == "N1")
+                                pdbpositions.push(new THREE.Vector3(na.x, na.y, na.z));
+                        }
+                        if (atoms.length == 0)
+                            prevResId = na.pdbResIdent;
+                        //checks if last read atom belongs to a different chain than the one before it
+                        if (prevResId != na.pdbResIdent) { // will trigger after first reside is read
+                            nr.resType = atoms[0].resType;
+                            nr.pdbResIdent = atoms[0].pdbResIdent;
+                            nr.atoms = atoms;
+                            let nrc = {
+                                ...nr
+                            };
+                            a1 = calcA1FromRes(nrc);
+                            firstres = false;
+                        }
+                        else {
+                            // copy is necessary
+                            let nac = {
+                                ...na
+                            };
+                            atoms.push(nac);
+                        }
+                    }
                     // Align via N1 positions for DNA & CA for proteins
                     if (!Amino && pdbLines[j].substring(12, 16).trim() == "N1") {
                         let x = parseFloat(pdbLines[j].substring(30, 38)) / 8.518;
@@ -1011,7 +1155,8 @@ function readPdbFile(file) {
                     }
                 }
             }
-            return pdbpositions;
+            // nr.atoms = this.atoms; //fill atoms array
+            return [pdbpositions, a1];
         };
         // load all Unique Chains
         initList.uniqueIDs.forEach((id, indx) => {
@@ -1022,18 +1167,27 @@ function readPdbFile(file) {
             // deal with repeats of each individual unique chain
             initList.repeatIDs.forEach((rid, rindx) => {
                 if (id.includes(rid)) { //Makes sure Chain IDs contain original chain identifier
-                    let alignME = getpdbpositions(initList.repeatStart[rindx], initList.repeatEnd[rindx], alignTO[0]);
-                    if (alignME.length != alignTO[1].length)
+                    let alignME = getpdbpositions(initList.repeatStart[rindx], initList.repeatEnd[rindx], alignTO[0]); // [0] -> pdb positions [1] -> a1 vector of first residue
+                    let firstresidueunique = uniqresidues[0];
+                    firstresidueunique.atoms = uniqatoms.filter(atom => atom.chainIndx == firstresidueunique.chainIndx && atom.pdbResIdent == firstresidueunique.pdbResIdent);
+                    let uniqa1 = calcA1FromRes(firstresidueunique);
+                    let repeata1 = alignME[1];
+                    if (alignME[0].length != alignTO[1].length)
                         notify("PDB Chains have unequal lengths");
-                    let alignMEcoord = alignME.map(x => { return x.clone(); }); //copy our arrays
-                    let newcoords = alignME.map(x => { return x.clone(); }); //copy our arrays
-                    let alignTOcoord = alignTO[1].map(x => { return x.clone(); }); //copy our arrays
-                    let uniqueCOM = alignTO[1].reduce((a, b) => a.add(b)).divideScalar(alignTO[1].length);
-                    let repeatCOM = alignME.reduce((a, b) => a.add(b)).divideScalar(alignME.length);
-                    let aME = alignMEcoord[0].clone().sub(repeatCOM).normalize();
-                    let aTO = alignTOcoord[0].clone().sub(uniqueCOM).normalize();
+                    // let alignMEcoord = alignME[0].map(x => {return x.clone()}); //copy our arrays
+                    let newcoords = alignME[0].map(x => { return x.clone(); }); //copy our arrays
+                    // let alignTOcoord = alignTO[1].map(x => {return x.clone()});//copy our arrays
+                    // let uniqueCOM = alignTO[1].reduce((a,b) => a.add(b)).divideScalar(alignTO[1].length);
+                    // let repeatCOM = alignME.reduce((a,b) => a.add(b)).divideScalar(alignME.length);
+                    //
+                    // let aME = alignMEcoord[0].clone().sub(repeatCOM).normalize();
+                    // let aTO = alignTOcoord[0].clone().sub(uniqueCOM).normalize();
+                    // notify(aME.x.toString() + " " + aME.y.toString() + " " + aME.z.toString());
+                    // notify(aTO.x.toString() + " " + aTO.y.toString() + " " + aTO.z.toString());
                     //Calc quaternion rotation between vectors
-                    let rotQuat = new THREE.Quaternion().setFromUnitVectors(aTO, aME);
+                    // let rotQuat = new THREE.Quaternion().setFromUnitVectors(uniqa1, repeata1);
+                    let rotQuat = new THREE.Quaternion().setFromUnitVectors(repeata1, uniqa1);
+                    // let rotQuat = new THREE.Quaternion().setFromUnitVectors(aME, aTO);
                     // let newcoords = alignMEcoord;
                     initList.repeatCoords[rindx] = newcoords;
                     initList.repeatQuatRots[rindx] = rotQuat;
@@ -1081,15 +1235,6 @@ function addPDBToScene() {
         // Looking back at this the strands name probably wasn't the most unique choice
         // strands is meant to be the chain object from the PDB Parser
         // Parses PDB Data and Intializes System, Errors go to the Console
-        //PDB Parsing
-        // Members of the Recongized arrays cannot have overlapping Members
-        const recongizedDNAResidues = ["DG", "DT", "DA", "DC", "DU", "DI", "DN"];
-        const recongizedDNAStrandEnds = ["DG3", "DG5", "DT3", "DT5", "DA3", "DA3", "DC3", "DC5"];
-        const recongizedProteinResidues = ["ALA", "ARG", "ASN", "ASP", "CYS", "GLN",
-            "GLU", "GLY", "HIS", "ILE", "MET", "LEU", "LYS", "PHE", "PRO", "SER",
-            "THR", "TRP", "TYR", "VAL", "SEC", "PYL", "ASX", "GLX", "UNK"];
-        const recongizedRNAResidues = ["A", "C", "G", "I", "U", "N"];
-        const recongizedRNAStrandEnds = ["A3", "A5", "C3", "C5", "G3", "G5", "U3", "U5"];
         // Intialize bookkeeping Members for Boolean Checks
         let checker = {
             DNAPresent: false,
@@ -1133,7 +1278,7 @@ function addPDBToScene() {
                     // Bookkeeping
                     checker.proteinPresent = true;
                 }
-                else if (recongizedRNAResidues.indexOf(res.resType) > -1) {
+                else if (recongizedRNAResidues.indexOf(res.resType) > -1 || recongizedRNAStrandEnds.indexOf(res.resType) > -1) {
                     // Deal with Special Cases Here
                     if (res.resType === 'N') {
                         notify("Nucleotide Number blank has Residue Base type 'N' for Generic Nucleic Acid in PDB File");
@@ -1176,6 +1321,7 @@ function addPDBToScene() {
         let proelem = {
             "LYS": "K",
             "CYS": "C",
+            "CYX": "C",
             "ALA": "A",
             "THR": "T",
             "GLU": "E",
@@ -1446,7 +1592,7 @@ function addPDBToScene() {
                 // Take care of repeats Access by Chain Identifier
                 initlist.repeatIDs.forEach((rid, indx) => {
                     if (nstrand.chainID.includes(rid)) {
-                        let repeatStrand = sys.addNewPeptideStrand();
+                        let repeatStrand = sys.addNewNucleicAcidStrand();
                         currentStrand.getMonomers(true).forEach((mon, mid) => {
                             let repeatNuc = repeatStrand.createBasicElement(nextElementId);
                             repeatNuc.sid = nextElementId - oldElementId;
@@ -1461,6 +1607,7 @@ function addPDBToScene() {
                             initInfo.push(rinfo);
                             repeatNuc.n3 = null;
                             repeatNuc.n5 = null;
+                            // monomers go 5' to 3'
                             if (mid != 0) {
                                 let prevaa = elements.get(nextElementId - 1); //Get previous Element
                                 repeatNuc.n3 = prevaa;
@@ -1482,7 +1629,7 @@ function addPDBToScene() {
         let FillInfoAA = (info, AM, CM) => {
             AM.type = info[1];
             let center = info[2].sub(CM);
-            AM.calcPositions(center, AM.a1, AM.a3, true);
+            AM.calcPositions(center, info[3], info[4], true);
         };
         // This Function calculates all necessary info for a Nuclcleotide in PDB format and writes it to the system
         let FillInfoNC = (info, NC, CM) => {

--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -643,9 +643,9 @@ function readHBondFile(file) {
         let hbonds = [];
         //process hbonds
         for (let i = 0; i < size - 1; i++) {
-            if (recongizedProteinResidues.indexOf(lines[i].substring(0, 3).trim()) != -1) { //check that its a protein residue
-                // trims all split items then removes the empty strings
-                let l = lines[i].split(" ").map(function (item) { return item.trim(); }).filter(n => n);
+            // trims all split items then removes the empty strings
+            let l = lines[i].split(" ").map(function (item) { return item.trim(); }).filter(n => n);
+            if (recongizedProteinResidues.indexOf(l[0]) != -1) { //check that its a protein residue
                 //extract values
                 const pos1 = l[1].split("."), atm1 = l[2], id2 = l[3], pos2 = l[4].split("."), atm2 = l[5], dist = parseFloat(l[8]);
                 if (recongizedProteinResidues.indexOf(id2) != -1) { //bonded to another protein residue
@@ -656,7 +656,17 @@ function readHBondFile(file) {
                     hbonds.push(hbond);
                 }
             }
+            else if (recongizedProteinResidues.indexOf(l[1]) != -1 && recongizedProteinResidues.indexOf(l[5]) != -1) { // residue is second listed indicates hbonds listed from models
+                //extract values
+                const pos1 = l[0].split(".")[1], atm1 = l[3], id1 = l[2], id2 = l[6], pos2 = l[4].split(".")[1], atm2 = l[7], dist = parseFloat(l[10]);
+                let pdbinds1 = [pos1, parseInt(id1)];
+                let pdbinds2 = [pos2, parseInt(id2)];
+                let hbond = [pdbinds1, pdbinds2];
+                hbonds.push(hbond);
+            }
         }
+        if (hbonds.length == 0)
+            notify("H bond file format is unrecongized");
         pdbFileInfo[pdbInfoIndx].hydrogenBonds = hbonds;
     };
     reader.readAsText(file);
@@ -820,7 +830,7 @@ function prep_pdb(pdblines) {
     // Find Chain Termination statements TER and uses
     for (let i = start; i < pdblines.length; i++) {
         if (pdblines[i].substr(0, 4) == 'ATOM' && noatom == false) {
-            firstatom = i;
+            firstatom = i; //line number of first atomic coordinate
             noatom = true;
         }
         if (pdblines[i].substr(0, 3) === 'TER') {
@@ -844,69 +854,86 @@ function prep_pdb(pdblines) {
     let bioassemblyassumption = false;
     if (modelDivs.length > 0)
         bioassemblyassumption = true;
-    // Look at line above chain termination for chain ID
-    let chainids = [];
-    chainDivs.forEach(d => {
-        chainids.push(pdblines[d - 1].substring(21, 22).trim());
-    });
-    //Re-Assign Chain Ids based off repeating or not
-    let sorted_repeated_chainids = [];
-    chainids.forEach((chain, ind) => {
-        if (chainids.indexOf(chain) != ind && bioassemblyassumption) { //Check for repeated and presence of models
-            sorted_repeated_chainids.push(chain);
-        }
-        else {
-            sorted_repeated_chainids.push(chain + "*"); // not a repeat? denoted as A*
-        }
-    });
     let nchainids = []; // Store new chainids
-    let fullalpha = [];
-    let lastindex = 1; //
-    let alphabet = 'a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.1.2.3.4.5.6.7.8.9.<.>.?./.!.@.#.$.%.^.&.*.(.)._.-.=.+'.split('.');
-    fullalpha = fullalpha.concat(alphabet);
-    // supports 2862 chains with the same chain id in the same pdb file
-    alphabet.forEach((id, idx, arr) => fullalpha = fullalpha.concat(arr.map(x => { return id + x; })));
-    sorted_repeated_chainids.forEach((val, ind) => {
-        if (nchainids.indexOf(val) != ind) { //same chain identifier needs to be fixed
-            if (val != "" && val.includes("*")) { //unique chain
-                let nval = val;
-                let attmpt_indx = lastindex;
-                while (nchainids.indexOf(nval) != -1 && attmpt_indx < 2862) {
-                    nval = fullalpha[attmpt_indx] + val;
-                    attmpt_indx += 1;
+    let finalids = []; // Final Ids to Loaded, can be from chains or models
+    let finaldivs = [];
+    if (chainDivs.length != 0) { // Assumes normal PDB file with all chains declared
+        // Look at line above chain termination for chain ID
+        let chainids = [];
+        chainDivs.forEach(d => {
+            chainids.push(pdblines[d - 1].substring(21, 22).trim());
+        });
+        //Re-Assign Chain Ids based off repeating or not
+        let sorted_repeated_chainids = [];
+        chainids.forEach((chain, ind) => {
+            if (chainids.indexOf(chain) != ind && bioassemblyassumption) { //Check for repeated and presence of models
+                sorted_repeated_chainids.push(chain);
+            }
+            else {
+                sorted_repeated_chainids.push(chain + "*"); // not a repeat? denoted as A*
+            }
+        });
+        let fullalpha = [];
+        let lastindex = 1; //
+        let alphabet = 'a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.1.2.3.4.5.6.7.8.9.<.>.?./.!.@.#.$.%.^.&.*.(.)._.-.=.+'.split('.');
+        fullalpha = fullalpha.concat(alphabet);
+        // supports 2862 chains with the same chain id in the same pdb file
+        alphabet.forEach((id, idx, arr) => fullalpha = fullalpha.concat(arr.map(x => { return id + x; })));
+        sorted_repeated_chainids.forEach((val, ind) => {
+            if (nchainids.indexOf(val) != ind) { //same chain identifier needs to be fixed
+                if (val != "" && val.includes("*")) { //unique chain
+                    let nval = val;
+                    let attmpt_indx = lastindex;
+                    while (nchainids.indexOf(nval) != -1 && attmpt_indx < 2862) {
+                        nval = fullalpha[attmpt_indx] + val;
+                        attmpt_indx += 1;
+                    }
+                    lastindex = attmpt_indx;
+                    nchainids.push(nval);
                 }
-                lastindex = attmpt_indx;
-                nchainids.push(nval);
+                else {
+                    nchainids.push(val);
+                }
             }
             else {
                 nchainids.push(val);
             }
-        }
-        else {
-            nchainids.push(val);
-        }
-    });
+        });
+        //important must be set
+        finalids = nchainids;
+        finaldivs = chainDivs;
+    }
+    else if (modelDivs.length != 0) {
+        // Assumes a malformed PDB with models but no chains, (looking at you Modeller)
+        bioassemblyassumption = false;
+        let chainids = [];
+        modelDivs.forEach((d, dindx) => {
+            chainids.push((dindx + 1).toString() + "*"); // Assumes all chains are unique since they weren't labeled
+        });
+        finalids = chainids;
+        finaldivs = modelDivs;
+    }
     // Stores ID, start line, end line if chain is unique
     // Stores Id, start line, end line, coordinates a if chain is repeated and Quat Rotation for a1
     // tl;dr  unique chains require more calculations while repeated chains can resuse those calculated parameters and shifts them accordingly
     // necessary for loading large things like Virus particles
     let initList = new pdbReadingList;
     let prevend = firstatom;
-    for (let i = 0; i < nchainids.length; i++) {
-        if (nchainids[i].includes("*")) {
-            let id = nchainids[i].replace('*', ''); // remove asterisk from chain id
+    for (let i = 0; i < finalids.length; i++) {
+        if (finalids[i].includes("*")) {
+            let id = finalids[i].replace('*', ''); // remove asterisk from chain id
             initList.uniqueIDs.push(id);
             initList.uniqueStart.push(prevend);
-            initList.uniqueEnd.push(chainDivs[i]);
-            prevend = chainDivs[i];
+            initList.uniqueEnd.push(finaldivs[i]);
+            prevend = finaldivs[i];
         }
         else {
-            initList.repeatIDs.push(nchainids[i]);
+            initList.repeatIDs.push(finalids[i]);
             initList.repeatStart.push(prevend);
-            initList.repeatEnd.push(chainDivs[i]);
+            initList.repeatEnd.push(finaldivs[i]);
             initList.repeatCoords.push([new THREE.Vector3(0, 0, 0)]);
             initList.repeatQuatRots.push(new THREE.Quaternion());
-            prevend = chainDivs[i];
+            prevend = finaldivs[i];
         }
     }
     return { "initlist": initList, "dsbonds": dsbonds };
@@ -1006,7 +1033,7 @@ function readPdbFile(file) {
                 return a1;
             }
         };
-        let chainindx = -1;
+        let chainindx = 0;
         let loadpdbsection = function (start, end) {
             pdbpositions = [];
             atoms = [];
@@ -1022,16 +1049,37 @@ function readPdbFile(file) {
                     na.atomType = pdbLine.substring(12, 16).trim();
                     na.altLoc = pdbLine.substring(16, 17).trim();
                     na.resType = pdbLine.substring(17, 20).trim();
-                    na.chainID = pdbLine.substring(21, 23).trim(); //changed to (21, 22) to (21, 23) to deal with 2 letter identifiers present in some PDB Files
-                    let tmp = pdbLine.substring(23, 29); // Usually the residue number
-                    //check for insertion code
-                    na.iCode = "";
-                    if (isNaN(parseInt(tmp[5]))) {
-                        na.iCode = tmp[5];
-                        na.pdbResIdent = tmp.slice(0, 5).trim();
+                    let chaincheck = pdbLine.substring(21, 22).trim() != ""; // chain is legit if filled at 21st character
+                    if (!chaincheck) { // file missing chain data?
+                        if (prevChainId == chainindx.toString()) {
+                            na.chainID = chainindx.toString();
+                        }
+                        else {
+                            na.chainID = (chainindx + 1).toString();
+                        }
+                        let tmp = pdbLine.substring(21, 27); // Location of residue identifer IF file is missing chain data
+                        //check for insertion code
+                        na.iCode = "";
+                        if (isNaN(parseInt(tmp[5]))) {
+                            na.iCode = tmp[5];
+                            na.pdbResIdent = tmp.slice(0, 5).trim();
+                        }
+                        else {
+                            na.pdbResIdent = tmp.trim();
+                        }
                     }
                     else {
-                        na.pdbResIdent = tmp.trim();
+                        na.chainID = pdbLine.substring(21, 23).trim(); //changed to (21, 22) to (21, 23) to deal with 2 letter identifiers present in some PDB Files
+                        let tmp = pdbLine.substring(23, 29); // Usually the residue number
+                        //check for insertion code
+                        na.iCode = "";
+                        if (isNaN(parseInt(tmp[5]))) {
+                            na.iCode = tmp[5];
+                            na.pdbResIdent = tmp.slice(0, 5).trim();
+                        }
+                        else {
+                            na.pdbResIdent = tmp.trim();
+                        }
                     }
                     // Convert From Angstroms to Simulation Units while we're at it
                     na.x = parseFloat(pdbLine.substring(30, 38)) / 8.518;

--- a/dist/model/aminoAcid.js
+++ b/dist/model/aminoAcid.js
@@ -13,6 +13,7 @@ class AminoAcid extends BasicElement {
     setPDBIndices(datasetindx, chainid, pdbresnum) {
         this.pdbindices = [datasetindx, chainid, pdbresnum];
     }
+    ;
     elemToColor(elem) {
         elem = { "K": 0, "C": 1, "A": 2, "T": 3, "E": 3, "S": 4, "D": 5, "N": 6, "Q": 7, "H": 8, "G": 10, "P": 11, "R": 12, "V": 13, "I": 14, "L": 15, "M": 16, "F": 17, "Y": 18, "W": 19 }[elem];
         if (elem == undefined)

--- a/dist/model/aminoAcid.js
+++ b/dist/model/aminoAcid.js
@@ -10,6 +10,9 @@ class AminoAcid extends BasicElement {
         this.a3 = new THREE.Vector3(0., 0., 0.);
     }
     ;
+    setPDBIndices(datasetindx, chainid, pdbresnum) {
+        this.pdbindices = [datasetindx, chainid, pdbresnum];
+    }
     elemToColor(elem) {
         elem = { "K": 0, "C": 1, "A": 2, "T": 3, "E": 3, "S": 4, "D": 5, "N": 6, "Q": 7, "H": 8, "G": 10, "P": 11, "R": 12, "V": 13, "I": 14, "L": 15, "M": 16, "F": 17, "Y": 18, "W": 19 }[elem];
         if (elem == undefined)

--- a/dist/model/basicElement.js
+++ b/dist/model/basicElement.js
@@ -5,6 +5,7 @@
  * @param dummySys - If created during editing, the data arrays for instancing are stored in a dummy system
  */
 class BasicElement {
+    // pdbid: string; //Only Intialized if loaded from a PDB structure
     constructor(id, strand) {
         this.connections = []; // ref all elements it's
         this.elementType = -1; // 0:A 1:G 2:C 3:T/U OR 1 of 20 amino acids

--- a/dist/model/network.js
+++ b/dist/model/network.js
@@ -220,6 +220,170 @@ class Network {
         }
     }
     ;
+    edgesMWCENM() {
+        this.reducedEdges.clearAll();
+        this.clearConnections();
+        this.selectNetwork();
+        let pdbindices;
+        try {
+            pdbindices = this.particles.map(e => { return e.pdbindices; });
+        }
+        catch (e) {
+            notify("PDB Info could not be found. Make sure only AminoAcids are selected and they have been loaded from a PDB file.");
+            return;
+        }
+        let uniqdatasets = new Set(pdbindices.map((a) => { return a[0]; }));
+        let uniqstrands = new Set(this.particles.map(x => { return x.strand; }));
+        let uniqchains = new Set(pdbindices.map((a) => { return a[1]; }));
+        this.addBackboneConnections(uniqdatasets);
+    }
+    ;
+    addHydrogenBonds() {
+        // Need Hydrogen Bonds File (Chimera)
+    }
+    addNonpolarBonds() {
+        let nonpolark = 1.0;
+        let nonpolarcheck = function (res1, res2) {
+            let pi = res1.pdbindices; // location of pdb information
+            let pdbres1 = pdbFileInfo[pi[0]].pdbsysinfo[pi[1]].residues.filter(res => { if (parseInt(res.pdbResIdent) == pi[2]) {
+                return true;
+            } })[0];
+            let res1atoms = pdbres1.atoms.filter(atom => { if (['CA', 'N', 'H', 'C', 'O'].indexOf(atom.atomType) != -1)
+                return true; }); // sidechain atoms
+            let ni = res2.pdbindices; // location of pdb information
+            let pdbres2 = pdbFileInfo[ni[0]].pdbsysinfo[ni[1]].residues.filter(res => { if (parseInt(res.pdbResIdent) == ni[2]) {
+                return true;
+            } })[0];
+            let res2atoms = pdbres2.atoms.filter(atom => { if (['CA', 'N', 'H', 'C', 'O'].indexOf(atom.atomType) != -1)
+                return true; }); // sidechain atoms
+            let pdbdist = function (atom1, atom2) {
+                return Math.sqrt(Math.pow(atom1.x - atom2.x, 2) + Math.pow(atom1.y - atom2.y, 2) + Math.pow(atom1.z - atom2.z, 2));
+            };
+            let makenonbonded = false;
+            res1atoms.forEach(pa => {
+                res2atoms.forEach(na => {
+                    if (pdbdist(pa, na) < 4) { // 4 A is the cutoff used in the original MWCENM paper
+                        makenonbonded = true;
+                    }
+                });
+            });
+            return makenonbonded;
+        };
+        this.particles.forEach((p1, ind1) => {
+            this.particles.forEach((p2, ind2) => {
+                if (this.elemcoords.distance(ind1, ind2) < 2) { // speed up the code a bit
+                    if (nonpolarcheck(p1, p2)) {
+                        let pindx = this.particles.indexOf(p1);
+                        let nindx = this.particles.indexOf(p2);
+                        this.reducedEdges.addEdge(pindx, nindx, this.elemcoords.distance(pindx, nindx), 's', nonpolark);
+                    }
+                }
+            });
+        });
+    }
+    ;
+    addSaltBridges(pH = 7) {
+        let saltbridgek = 10;
+        let catres;
+        let anres;
+        let catatoms;
+        let anatoms;
+        if (pH == 7) {
+            catres = ["D", "E"]; // aspartic acid and glutamic acid
+            catatoms = { "D": ["OD1", "OD2"], "E": ["OE1", "AE1", "OE2", "AE2"] }; // Which atoms might hold the charge
+            anres = ["K", "H", "R"]; // Lysine, histidine and Arginine
+            anatoms = { "H": ["ND1", "AD1"], "K": ["NZ"], "R": ["NH1", "NH2"] }; // Which atoms might hold the charge
+        }
+        else {
+            notify("No pH besides 7 currently supported");
+        }
+        let posresidues = this.particles.filter(x => { if (catres.indexOf(x.type) != -1)
+            return true; }); // all particles in network that are positive
+        let negresidues = this.particles.filter(x => { if (anres.indexOf(x.type) != -1)
+            return true; }); // all particles in network that are negative
+        let saltbridgecheck = function (posres, negres) {
+            let pi = posres.pdbindices; // location of pdb information
+            let pospdbres = pdbFileInfo[pi[0]].pdbsysinfo[pi[1]].residues.filter(res => { if (parseInt(res.pdbResIdent) == pi[2]) {
+                return true;
+            } })[0];
+            let posatoms = pospdbres.atoms.filter(atom => { if (catatoms[posres.type].indexOf(atom.atomType) != -1)
+                return true; });
+            let ni = negres.pdbindices; // location of pdb information
+            let negpdbres = pdbFileInfo[ni[0]].pdbsysinfo[ni[1]].residues.filter(res => { if (parseInt(res.pdbResIdent) == ni[2]) {
+                return true;
+            } })[0];
+            let negatoms = negpdbres.atoms.filter(atom => { if (anatoms[negres.type].indexOf(atom.atomType) != -1)
+                return true; });
+            let pdbdist = function (atom1, atom2) {
+                return Math.sqrt(Math.pow(atom1.x - atom2.x, 2) + Math.pow(atom1.y - atom2.y, 2) + Math.pow(atom1.z - atom2.z, 2));
+            };
+            let makesaltbridge = false;
+            posatoms.forEach(pa => {
+                negatoms.forEach(na => {
+                    if (pdbdist(pa, na) < 4) { // 4 A is the cutoff used in the original MWCENM paper
+                        makesaltbridge = true;
+                    }
+                });
+            });
+            return makesaltbridge;
+        };
+        // Checks all combinations of paired residues for
+        posresidues.forEach(pr => {
+            negresidues.forEach(nr => {
+                if (saltbridgecheck(pr, nr)) {
+                    let pindx = this.particles.indexOf(pr);
+                    let nindx = this.particles.indexOf(nr);
+                    this.reducedEdges.addEdge(pindx, nindx, this.elemcoords.distance(pindx, nindx), 's', saltbridgek);
+                }
+            });
+        });
+    }
+    ;
+    addDisulphideBonds(uniqdatasets, pdbindices) {
+        [...uniqdatasets].forEach(ud => {
+            let dsbonds = pdbFileInfo[ud].disulphideBonds;
+            let chains = pdbFileInfo[ud].pdbsysinfo;
+            let p1, p2;
+            let p1found, p2found;
+            let k = 100; // strength of disulfide bond
+            dsbonds.forEach((db) => {
+                p1found = false;
+                p2found = false;
+                pdbindices.filter((pi, pindx) => {
+                    if (pi[0] == ud && pi[1] == db[0] && pi[2] == db[1]) {
+                        p1 = this.particles[pindx];
+                    }
+                    else if (pi[0] == ud && pi[1] == db[2] && pi[2] == db[3]) {
+                        p2 = this.particles[pindx];
+                    }
+                });
+                if (p1found && p2found) {
+                    let p1indx = this.particles.indexOf(p1);
+                    let p2indx = this.particles.indexOf(p2);
+                    this.reducedEdges.addEdge(p1indx, p2indx, this.elemcoords.distance(p1indx, p2indx), 's', k);
+                }
+                else {
+                    notify("Disulphide Bond could not be parsed from pdb info");
+                    return;
+                }
+            });
+        });
+    }
+    ;
+    addBackboneConnections(uniqstrands) {
+        let covalentk = 100;
+        [...uniqstrands].forEach(str => {
+            let monos = str.getMonomers();
+            monos.forEach(x => {
+                let pind = this.particles.indexOf(x);
+                let qind = this.particles.indexOf(x.n3);
+                if (pind != -1 && this.particles.indexOf(x.n5) != -1) {
+                    this.reducedEdges.addEdge(pind, qind, this.elemcoords.distance(pind, qind), 's', covalentk);
+                }
+            });
+        });
+    }
+    ;
     generateHessian() {
         if (this.particles.length > 2000) {
             notify("Large Networks (n>2000) cannot be solved here. Please use the Python scripts provided at URMOM");

--- a/dist/model/network.js
+++ b/dist/model/network.js
@@ -136,6 +136,8 @@ class Network {
     ;
     sendtoUI() {
         this.fittingReady = true;
+        if (flux.fluxWindowOpen)
+            view.addNetworkData(this.nid);
     }
     ;
     fillVec(vecName, unitSize, pos, vals) {
@@ -260,6 +262,7 @@ class Network {
         // network is ready for solving and visualization
         this.networktype = "MWCENM";
         if (this.reducedEdges.total != 0) {
+            // this.reducedEdges.ks = this.reducedEdges.ks.map(x => 10*x) // mwcenm isn't super great
             this.initInstances(this.reducedEdges.total);
             this.initEdges();
             this.prepVis();
@@ -303,6 +306,7 @@ class Network {
     }
     addNonpolarBonds() {
         let nonpolark = 1.0;
+        let np = 12;
         // checks for atoms within 4 residues of one another on two amino acids
         // let nonpolarcheck = function(res1, res2){ // looks for pairs of atoms from different residues within 4 Angstroms
         //
@@ -447,7 +451,10 @@ class Network {
                 let qind = this.particles.indexOf(p.n3);
                 if (qind != -1) {
                     notify("backbone Bond " + i.toString() + " " + qind.toString());
-                    this.reducedEdges.addEdge(qind, i, this.elemcoords.distance(i, qind), 's', covalentk);
+                    let dis = this.elemcoords.distance(i, qind);
+                    if (dis < 1) { // removes any obviously incorrect backbone bonds
+                        this.reducedEdges.addEdge(qind, i, this.elemcoords.distance(i, qind), 's', covalentk);
+                    }
                 }
             }
         }

--- a/dist/model/network.js
+++ b/dist/model/network.js
@@ -12,22 +12,25 @@ class Edges {
         this.extraParams = [];
     }
     addEdge(id1, id2, eqdist, type, k = 1, xparams = []) {
-        if (id1 < id2) {
-            this.p1.push(id1);
-            this.p2.push(id2);
-            this.ks.push(k);
-            this.types.push(type);
-            this.eqDist.push(eqdist);
-            this.extraParams.push(xparams);
-            this.total += 1;
+        if (id1 == id2)
+            return; // Can't Add Edge to Itself
+        let ind = this.checkEdge(id1, id2, eqdist);
+        if (ind > 0) {
+            this.ks[ind] += k; // additive spring constants, I did this for MWCENM hopefully it doesn't bite me later
         }
-        else if (id2 > id1) {
-            this.p1.push(id2);
-            this.p2.push(id1);
+        else {
+            if (id1 < id2) {
+                this.p1.push(id1);
+                this.p2.push(id2);
+            }
+            else if (id1 > id2) {
+                this.p1.push(id2);
+                this.p2.push(id1);
+            }
             this.ks.push(k);
+            this.types.push(type);
             this.eqDist.push(eqdist);
             this.extraParams.push(xparams);
-            this.types.push(type);
             this.total += 1;
         }
     }
@@ -46,6 +49,18 @@ class Edges {
                 this.total -= 1;
                 break;
             }
+        }
+    }
+    ;
+    checkEdge(id1, id2, eqdist) {
+        let dist = this.eqDist.indexOf(eqdist);
+        if (dist > -1) {
+            if ((this.p1[dist] == id1 && this.p2[dist] == id2) || (this.p2[dist] == id1 && this.p1[dist] == id2)) {
+                return dist;
+            }
+        }
+        else {
+            return dist;
         }
     }
     ;
@@ -258,7 +273,7 @@ class Network {
             let hbonds = pdbFileInfo[ud].hydrogenBonds;
             // let chains = pdbFileInfo[ud].pdbsysinfo;
             let p1, p2; // will be refences to corresponding particles
-            let p1found, p2found; // bool indica
+            let p1found, p2found; // bools
             let hbondk = 100; // strength of h bond
             hbonds.forEach((hb, hid) => {
                 p1found = false;
@@ -369,7 +384,7 @@ class Network {
             let makesaltbridge = false;
             posatoms.forEach(pa => {
                 negatoms.forEach(na => {
-                    if (pdbdist(pa, na) < 4) { // 4 A is the cutoff used in the original MWCENM paper
+                    if (pdbdist(pa, na) < 4 / 8.518) { // 4 A is the cutoff used in the original MWCENM paper
                         makesaltbridge = true;
                     }
                 });

--- a/dist/model/network.js
+++ b/dist/model/network.js
@@ -75,22 +75,24 @@ class Network {
         this.networktype = 'empty';
         this.onscreen = false;
         this.elemcoords = {
-            coords: this.particles.map(e => e.getPos()),
-            // xI: selectedMonomers.map(e => e.getPos().x),
-            // yI: selectedMonomers.map(e => e.getPos().y),
-            // zI: selectedMonomers.map(e => e.getPos().z),
+            // coords: this.particles.map(e => e.getPos()),
+            xI: selectedMonomers.map(e => e.getPos().x),
+            yI: selectedMonomers.map(e => e.getPos().y),
+            zI: selectedMonomers.map(e => e.getPos().z),
             distance: function (i, j) {
-                return this.coords[i].distanceTo(this.coords[j]);
-                // return Math.sqrt((this.xI[i] - this.xI[j])**2 + (this.yI[i] - this.yI[j])**2 + (this.zI[i] - this.zI[j])**2)
+                // return this.coords[i].distanceTo(this.coords[j]);
+                return Math.sqrt((this.xI[i] - this.xI[j]) ** 2 + (this.yI[i] - this.yI[j]) ** 2 + (this.zI[i] - this.zI[j]) ** 2);
             },
             rotation: function (i, j) {
-                return new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), this.coords[i].clone().sub(this.coords[j]).normalize()
-                // THREE.Vector3(this.xI[i]-this.xI[j],this.yI[i]-this.yI[j], this.zI[i]-this.zI[j]).normalize()
-                );
+                return new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), //this.coords[i].clone().sub(this.coords[j]).normalize()
+                new THREE.Vector3(this.xI[i] - this.xI[j], this.yI[i] - this.yI[j], this.zI[i] - this.zI[j]).normalize());
             },
             center: function (i, j) {
-                return this.coords[i].clone().add(this.coords[j]).divideScalar(2);
-                // return new THREE.Vector3((this.xI[i]+this.xI[j])/2, (this.yI[i]+this.yI[j])/2, (this.zI[i]+this.zI[j])/2);
+                // return this.coords[i].clone().add(this.coords[j]).divideScalar(2);
+                return new THREE.Vector3((this.xI[i] + this.xI[j]) / 2, (this.yI[i] + this.yI[j]) / 2, (this.zI[i] + this.zI[j]) / 2);
+            },
+            diff: function (i, j) {
+                return new THREE.Vector3((this.xI[j] - this.xI[i]), (this.yI[j] - this.yI[i]), (this.zI[j] - this.zI[i]));
             }
         };
         flux.prepJSONButton(nid);
@@ -199,8 +201,8 @@ class Network {
         // go through coordinates and assign connections if 2 particles
         // are less than the cutoff value apart
         let simCutoffValue = cutoffValueAngstroms / 8.518; //sim unit conversion
-        for (let i = 0; i < this.elemcoords.coords.length; i++) {
-            for (let j = 1; j < this.elemcoords.coords.length; j++) {
+        for (let i = 0; i < this.elemcoords.xI.length; i++) {
+            for (let j = 1; j < this.elemcoords.xI.length; j++) {
                 if (i >= j)
                     continue;
                 let dij = this.elemcoords.distance(i, j);
@@ -233,53 +235,98 @@ class Network {
             return;
         }
         let uniqdatasets = new Set(pdbindices.map((a) => { return a[0]; }));
-        let uniqstrands = new Set(this.particles.map(x => { return x.strand; }));
-        let uniqchains = new Set(pdbindices.map((a) => { return a[1]; }));
-        this.addBackboneConnections(uniqdatasets);
+        // let uniqstrands = new Set<Strand>(this.particles.map(x => {return x.strand}));
+        // let uniqchains = new Set<any>(pdbindices.map((a) => {return a[1]}));
+        this.addBackboneConnections();
+        this.addHydrogenBonds(uniqdatasets, pdbindices);
+        this.addDisulphideBonds(uniqdatasets, pdbindices);
+        this.addNonpolarBonds();
+        this.addSaltBridges(7);
+        // network is ready for solving and visualization
+        this.networktype = "MWCENM";
+        if (this.reducedEdges.total != 0) {
+            this.initInstances(this.reducedEdges.total);
+            this.initEdges();
+            this.prepVis();
+            this.sendtoUI();
+            this.fillConnections();
+        }
     }
     ;
-    addHydrogenBonds() {
-        // Need Hydrogen Bonds File (Chimera)
-    }
-    addNonpolarBonds() {
-        let nonpolark = 1.0;
-        let nonpolarcheck = function (res1, res2) {
-            let pi = res1.pdbindices; // location of pdb information
-            let pdbres1 = pdbFileInfo[pi[0]].pdbsysinfo[pi[1]].residues.filter(res => { if (parseInt(res.pdbResIdent) == pi[2]) {
-                return true;
-            } })[0];
-            let res1atoms = pdbres1.atoms.filter(atom => { if (['CA', 'N', 'H', 'C', 'O'].indexOf(atom.atomType) != -1)
-                return true; }); // sidechain atoms
-            let ni = res2.pdbindices; // location of pdb information
-            let pdbres2 = pdbFileInfo[ni[0]].pdbsysinfo[ni[1]].residues.filter(res => { if (parseInt(res.pdbResIdent) == ni[2]) {
-                return true;
-            } })[0];
-            let res2atoms = pdbres2.atoms.filter(atom => { if (['CA', 'N', 'H', 'C', 'O'].indexOf(atom.atomType) != -1)
-                return true; }); // sidechain atoms
-            let pdbdist = function (atom1, atom2) {
-                return Math.sqrt(Math.pow(atom1.x - atom2.x, 2) + Math.pow(atom1.y - atom2.y, 2) + Math.pow(atom1.z - atom2.z, 2));
-            };
-            let makenonbonded = false;
-            res1atoms.forEach(pa => {
-                res2atoms.forEach(na => {
-                    if (pdbdist(pa, na) < 4) { // 4 A is the cutoff used in the original MWCENM paper
-                        makenonbonded = true;
+    addHydrogenBonds(uniqdatasets, pdbindices) {
+        [...uniqdatasets].forEach(ud => {
+            let hbonds = pdbFileInfo[ud].hydrogenBonds;
+            // let chains = pdbFileInfo[ud].pdbsysinfo;
+            let p1, p2; // will be refences to corresponding particles
+            let p1found, p2found; // bool indica
+            let hbondk = 100; // strength of h bond
+            hbonds.forEach((hb, hid) => {
+                p1found = false;
+                p2found = false;
+                pdbindices.forEach((pi, pindx) => {
+                    if (pi[0] == ud && pi[1] == hb[0][0] && pi[2] == hb[0][1]) {
+                        p1 = this.particles[pindx];
+                        p1found = true;
+                    }
+                    if (pi[0] == ud && pi[1] == hb[1][0] && pi[2] == hb[1][1]) {
+                        p2 = this.particles[pindx];
+                        p2found = true;
                     }
                 });
-            });
-            return makenonbonded;
-        };
-        this.particles.forEach((p1, ind1) => {
-            this.particles.forEach((p2, ind2) => {
-                if (this.elemcoords.distance(ind1, ind2) < 2) { // speed up the code a bit
-                    if (nonpolarcheck(p1, p2)) {
-                        let pindx = this.particles.indexOf(p1);
-                        let nindx = this.particles.indexOf(p2);
-                        this.reducedEdges.addEdge(pindx, nindx, this.elemcoords.distance(pindx, nindx), 's', nonpolark);
-                    }
+                if (p1found && p2found) {
+                    let p1indx = this.particles.indexOf(p1);
+                    let p2indx = this.particles.indexOf(p2);
+                    notify("hbond " + p1indx.toString() + " " + p2indx.toString());
+                    this.reducedEdges.addEdge(p1indx, p2indx, this.elemcoords.distance(p1indx, p2indx), 's', hbondk);
+                }
+                else {
+                    notify("Hydrogen Bond could not be parsed from pdb info " + hid.toString());
+                    return;
                 }
             });
         });
+    }
+    addNonpolarBonds() {
+        let nonpolark = 1.0;
+        // checks for atoms within 4 residues of one another on two amino acids
+        // let nonpolarcheck = function(res1, res2){ // looks for pairs of atoms from different residues within 4 Angstroms
+        //
+        //     let pi = (res1 as AminoAcid).pdbindices; // location of pdb information
+        //     let pdbres1 = pdbFileInfo[pi[0]].pdbsysinfo.filter(chns => {if(chns.chainID == pi[1]) return true;})[0].residues.filter(res => {if (parseInt(res.pdbResIdent) == pi[2]){ return true;} })[0];
+        //     let res1atoms = pdbres1.atoms.filter(atom => {if(['CA', 'N', 'H', 'C', 'O'].indexOf(atom.atomType) == -1) return true;}); // sidechain atoms for res1 by filtering out main chain
+        //
+        //     let ni = (res2 as AminoAcid).pdbindices; // location of pdb information
+        //     let pdbres2 = pdbFileInfo[ni[0]].pdbsysinfo.filter(chns => {if(chns.chainID == ni[1]) return true;})[0].residues.filter(res => {if (parseInt(res.pdbResIdent) == ni[2]){ return true;} })[0];
+        //     let res2atoms = pdbres2.atoms.filter(atom => {if(['CA', 'N', 'H', 'C', 'O'].indexOf(atom.atomType) == -1) return true;}); // sidechain atoms for res2
+        //
+        //     let pdbdist = function(atom1, atom2){
+        //         return Math.sqrt(Math.pow(atom1.x - atom2.x,2) + Math.pow(atom1.y - atom2.y, 2) + Math.pow(atom1.z - atom2.z, 2));
+        //     }
+        //
+        //     let makenonbonded=false;
+        //
+        //     res1atoms.forEach(pa => {
+        //         res2atoms.forEach(na => {
+        //             if(pdbdist(pa, na) < 4){ // 4 A is the cutoff used in the original MWCENM paper
+        //                 makenonbonded=true;
+        //             }
+        //         })
+        //     })
+        //
+        //     return makenonbonded;
+        // }
+        for (let i = 0; i < this.particles.length; i++) {
+            for (let j = 0; j < this.particles.length; j++) {
+                if (i >= j)
+                    continue;
+                if (this.elemcoords.distance(i, j) < 4 / 8.518) { // 4 A is the cutoff used in the original MWCENM paper
+                    if (this.particles[i].n3 != this.particles[j] && this.particles[i].n5 != this.particles[j]) {
+                        notify("nonpolar Bond " + i.toString() + " " + j.toString());
+                        this.reducedEdges.addEdge(i, j, this.elemcoords.distance(i, j), 's', nonpolark);
+                    }
+                }
+            }
+        }
     }
     ;
     addSaltBridges(pH = 7) {
@@ -303,13 +350,15 @@ class Network {
             return true; }); // all particles in network that are negative
         let saltbridgecheck = function (posres, negres) {
             let pi = posres.pdbindices; // location of pdb information
-            let pospdbres = pdbFileInfo[pi[0]].pdbsysinfo[pi[1]].residues.filter(res => { if (parseInt(res.pdbResIdent) == pi[2]) {
+            let pospdbres = pdbFileInfo[pi[0]].pdbsysinfo.filter(chns => { if (chns.chainID == pi[1])
+                return true; })[0].residues.filter(res => { if (parseInt(res.pdbResIdent) == pi[2]) {
                 return true;
             } })[0];
             let posatoms = pospdbres.atoms.filter(atom => { if (catatoms[posres.type].indexOf(atom.atomType) != -1)
                 return true; });
             let ni = negres.pdbindices; // location of pdb information
-            let negpdbres = pdbFileInfo[ni[0]].pdbsysinfo[ni[1]].residues.filter(res => { if (parseInt(res.pdbResIdent) == ni[2]) {
+            let negpdbres = pdbFileInfo[ni[0]].pdbsysinfo.filter(chns => { if (chns.chainID == ni[1])
+                return true; })[0].residues.filter(res => { if (parseInt(res.pdbResIdent) == ni[2]) {
                 return true;
             } })[0];
             let negatoms = negpdbres.atoms.filter(atom => { if (anatoms[negres.type].indexOf(atom.atomType) != -1)
@@ -333,6 +382,7 @@ class Network {
                 if (saltbridgecheck(pr, nr)) {
                     let pindx = this.particles.indexOf(pr);
                     let nindx = this.particles.indexOf(nr);
+                    notify("salt b " + pindx.toString() + pr.type + " " + nindx.toString() + nr.type);
                     this.reducedEdges.addEdge(pindx, nindx, this.elemcoords.distance(pindx, nindx), 's', saltbridgek);
                 }
             });
@@ -342,46 +392,50 @@ class Network {
     addDisulphideBonds(uniqdatasets, pdbindices) {
         [...uniqdatasets].forEach(ud => {
             let dsbonds = pdbFileInfo[ud].disulphideBonds;
-            let chains = pdbFileInfo[ud].pdbsysinfo;
             let p1, p2;
             let p1found, p2found;
             let k = 100; // strength of disulfide bond
-            dsbonds.forEach((db) => {
-                p1found = false;
-                p2found = false;
-                pdbindices.filter((pi, pindx) => {
-                    if (pi[0] == ud && pi[1] == db[0] && pi[2] == db[1]) {
-                        p1 = this.particles[pindx];
+            if (dsbonds.length != 0) {
+                dsbonds.forEach((db) => {
+                    p1found = false;
+                    p2found = false;
+                    pdbindices.forEach((pi, pindx) => {
+                        if (pi[0] == ud && pi[1] == db[0] && pi[2] == db[1]) {
+                            p1 = this.particles[pindx];
+                            p1found = true;
+                        }
+                        else if (pi[0] == ud && pi[1] == db[2] && pi[2] == db[3]) {
+                            p2 = this.particles[pindx];
+                            p2found = true;
+                        }
+                    });
+                    if (p1found && p2found) {
+                        let p1indx = this.particles.indexOf(p1); // edges filled by particles position in the particles array of network
+                        let p2indx = this.particles.indexOf(p2);
+                        this.reducedEdges.addEdge(p1indx, p2indx, this.elemcoords.distance(p1indx, p2indx), 's', k);
                     }
-                    else if (pi[0] == ud && pi[1] == db[2] && pi[2] == db[3]) {
-                        p2 = this.particles[pindx];
+                    else {
+                        notify("Disulphide Bond could not be parsed from pdb info");
+                        return;
                     }
                 });
-                if (p1found && p2found) {
-                    let p1indx = this.particles.indexOf(p1);
-                    let p2indx = this.particles.indexOf(p2);
-                    this.reducedEdges.addEdge(p1indx, p2indx, this.elemcoords.distance(p1indx, p2indx), 's', k);
-                }
-                else {
-                    notify("Disulphide Bond could not be parsed from pdb info");
-                    return;
-                }
-            });
+            }
         });
     }
     ;
-    addBackboneConnections(uniqstrands) {
+    addBackboneConnections() {
+        // adds every particles n3 connection if n3 is in the particles array
         let covalentk = 100;
-        [...uniqstrands].forEach(str => {
-            let monos = str.getMonomers();
-            monos.forEach(x => {
-                let pind = this.particles.indexOf(x);
-                let qind = this.particles.indexOf(x.n3);
-                if (pind != -1 && this.particles.indexOf(x.n5) != -1) {
-                    this.reducedEdges.addEdge(pind, qind, this.elemcoords.distance(pind, qind), 's', covalentk);
+        for (let i = 0; i < this.particles.length; i++) {
+            let p = this.particles[i];
+            if (p.n3 != null) {
+                let qind = this.particles.indexOf(p.n3);
+                if (qind != -1) {
+                    notify("backbone Bond " + i.toString() + " " + qind.toString());
+                    this.reducedEdges.addEdge(qind, i, this.elemcoords.distance(i, qind), 's', covalentk);
                 }
-            });
-        });
+            }
+        }
     }
     ;
     generateHessian() {
@@ -397,7 +451,7 @@ class Network {
             //Initialize Empty Hessian (3Nx3N)
             let tmp = new Array(3 * this.particles.length); //3N
             for (let i = 0; i < 3 * this.particles.length; i++) { //3N x
-                hessian.push(tmp);
+                hessian.push(tmp.slice());
                 for (let j = 0; j < 3 * this.particles.length; j++) {
                     hessian[i][j] = 0;
                 }
@@ -405,16 +459,14 @@ class Network {
             //Hessian Calc w/ Masses
             for (let l = 0; l < this.reducedEdges.total; l++) {
                 let i = this.reducedEdges.p1[l], j = this.reducedEdges.p2[l], k = this.reducedEdges.ks[l];
-                let ip = this.elemcoords[i]; //Particle i Position
-                let jp = this.elemcoords[j]; //Particle j Position
                 let mi = this.masses[i];
                 let mj = this.masses[j];
                 let mij = Math.sqrt(mi * mj); //masses
                 let mi2 = mi * mi;
                 let mj2 = mj * mj;
-                let d = ip.distanceTo(jp); //distances
+                let d = this.elemcoords.distance(i, j); //distances
                 let d2 = d * d;
-                let diff = jp.sub(ip);
+                let diff = this.elemcoords.diff(i, j);
                 let diag = diff.clone().multiply(diff).multiplyScalar(k).divideScalar(d2);
                 let xy = k * (diff.x * diff.y) / d2;
                 let xz = k * (diff.x * diff.z) / d2;

--- a/index.html
+++ b/index.html
@@ -726,8 +726,7 @@
                 </div>
 
                 <div class="tight group flex-column">
-                    <button class="ribbon-button" onclick="view.toggleWindow('fluctuationWindow', flux.initializeGraph());"
-                            title="Preview expected fluctuations of networks">
+                    <button class="ribbon-button" onclick="view.toggleFluxWindow('fluctuationWindow', flux.initChart());" title="Preview expected fluctuations of networks">
                         <span class="mif-flow-cascade mif-3x"></span>
                         <span class="caption">Fluctuation Solver</span>
                     </button>

--- a/index.html
+++ b/index.html
@@ -713,6 +713,7 @@
                                 <button class="button dropdown-toggle">Assign Edges</button>
                                 <ul class="d-menu put-left" data-role="dropdown" id="edges" title="Assigns Edges to Network Selected by Network Selector">
                                     <li onclick="fillEdgesWrapper(selectednetwork, 0)">Cutoff (ANM)</li>
+                                    <li onclick="fillEdgesWrapper(selectednetwork, 1)">MWCENM</li>
                                 </ul>
                             </div>
 

--- a/ts/UI/UI.ts
+++ b/ts/UI/UI.ts
@@ -501,10 +501,14 @@ class View {
         let elem = this.doc.getElementById(id);
         if (elem) {
             Metro.window.toggle(elem);
-            // flux.fluxWindowOpen = !flux.fluxWindowOpen;
+            flux.fluxWindowOpen = !flux.fluxWindowOpen;
+            if(flux.fluxWindowOpen) flux.loadDatasetsandNetworks();
+            else flux.flushDatasetsandNetworks();
             // flux.flushDatasetsandNetworks();
         } else {
-            this.createFluxWindow(id, oncreate, flux.toggleDatasetsandNetworks, flux.flushDatasetsandNetworks);
+            this.createFluxWindow(id, oncreate, flux.toggleDatasetsandNetworks, flux.toggleDatasetsandNetworks);
+            flux.fluxWindowOpen = true;
+            flux.loadDatasetsandNetworks();
         }
     }
 
@@ -519,19 +523,23 @@ class View {
         );
     }
 
-    public createFluxWindow(id: string, oncreate?: ()=>void, ontoggle?: ()=>void, onclose?: ()=>void) {
+    public createFluxWindow(id: string, oncreate?: ()=>void, ontoggle?: ()=>void, onload?: ()=>void) {
         fetch(`windows/${id}.json`)
             .then(response => response.json())
             .then(data => {
                     let w = Metro.window.create(data);
                     w[0].id = id;
                     w.load(`windows/${id}.html`).then(oncreate);
-                    w[0].ontoggle = ontoggle();
+                    // w[0].ontoggle = ontoggle();
+
+                    // w[0].onload = onload();
+
                     // w[0].onclose = () => {
                     //     flux.flushDatasetsandNetworks();
                     //     notify("UNLDING");
                     // }
-                    // w[0].onclose = onclose();
+                    // w.data-close-action = ontoggle();
+                    // w[0].closeAction = onload();
                 }
             );
     }
@@ -606,27 +614,34 @@ class View {
 
     //Network Selector Methods (Protein tab)
     public addNetwork(nid : number){
-        let ul = document.getElementById("networks")
-        let li = document.createElement("li");
         let name = "Network " + (nid+1).toString();
-        li.setAttribute('id', name);
-        li.appendChild(document.createTextNode(name));
-        li.setAttribute("onclick", String(selectednetwork = nid));
-        ul.appendChild(li);
+        let exists = !!document.getElementById(name);
+        if(!exists){
+            let ul = document.getElementById("networks")
+            let li = document.createElement("li");
+            li.setAttribute('id', name);
+            li.appendChild(document.createTextNode(name));
+            li.setAttribute("onclick", String(selectednetwork = nid));
+            ul.appendChild(li);
+        }
     }
 
     public removeNetwork(nid: number){
-        let ul = document.getElementById("networks");
         let name = "Network " + (nid+1).toString();
-        let item = document.getElementById(name);
-        ul.removeChild(item);
+        let exists = !!document.getElementById(name);
+        if(exists) {
+            let ul = document.getElementById("networks");
+            let name = "Network " + (nid + 1).toString();
+            let item = document.getElementById(name);
+            ul.removeChild(item);
+        }
     }
 
     public toggleDataset(gid: number){
         let GD = graphDatasets[gid];
         let name = "Dataset: " + GD.label + " Format: " + GD.datatype;
-        let x = document.getElementById(name);
-        if(typeof(x) != 'undefined' && x != null){
+        let exists = !!document.getElementById(name);
+        if(!exists){
             //exists
             this.removeGraphData(gid);
         } else {
@@ -634,53 +649,64 @@ class View {
         }
     }
 
+    // UI methods for adding and removing info from lists in Fluctuation tab
     public addGraphData(gid : number){
         let GD = graphDatasets[gid];
-        let ul = document.getElementById("datalist") //In fluctuation Window
-        let li = document.createElement("li");
-        let sp1 = document.createElement("span");
-        let sp2 = document.createElement("span")
-        sp1.setAttribute('class', 'label');
-        sp2.setAttribute('class', 'second-label');
-        sp1.appendChild(document.createTextNode(GD.label));
-        sp2.appendChild(document.createTextNode(GD.datatype));
-        let name = "Dataset: " + GD.label + " Format: " + GD.datatype;
-        li.setAttribute('id', name);
-        li.setAttribute('value', String(gid));
-        li.appendChild(sp1);
-        li.appendChild(sp2);
-        li.onclick = function() {flux.toggleData(li.value)};
-        ul.appendChild(li);
-    }
-
-    public addNetworkData(nid: number){
-        if(networks[nid].fittingReady) { // only adds networks if they are ready (edges filled basically)
-            let ul = document.getElementById("readynetlist") //In fluctuation Window
+        let name = "Dataset: " + GD.label + " Format: " + GD.oDatatype; // Main label
+        let elementExists = !!document.getElementById(name); // boolean return if element exists
+        if(!elementExists){
+            let ul = document.getElementById("datalist") //In fluctuation Window
             let li = document.createElement("li");
             let sp1 = document.createElement("span");
             let sp2 = document.createElement("span")
             sp1.setAttribute('class', 'label');
             sp2.setAttribute('class', 'second-label');
-            let name = "Network " + (nid + 1).toString();
-            sp1.appendChild(document.createTextNode(name));
-            sp2.appendChild(document.createTextNode(networks[nid].networktype));
+            sp1.appendChild(document.createTextNode(GD.label));
+            sp2.appendChild(document.createTextNode(GD.oDatatype));
             li.setAttribute('id', name);
-            li.setAttribute('value', String(nid));
+            li.setAttribute('value', String(gid));
             li.appendChild(sp1);
             li.appendChild(sp2);
-            li.onclick = function () {
-                flux.fitData(li.value)
-            };
+            li.onclick = function() {flux.toggleData(li.value)};
             ul.appendChild(li);
+        }
+    }
+
+    public addNetworkData(nid: number){
+        let name = "Network " + (nid+1).toString();
+        let exists = !!document.getElementById(name);
+        if(!exists) {
+            if (networks[nid].fittingReady) { // only adds networks if they are ready (edges filled basically)
+                let ul = document.getElementById("readynetlist") //In fluctuation Window
+                let li = document.createElement("li");
+                let sp1 = document.createElement("span");
+                let sp2 = document.createElement("span")
+                sp1.setAttribute('class', 'label');
+                sp2.setAttribute('class', 'second-label');
+                let name = "Network " + (nid + 1).toString();
+                sp1.appendChild(document.createTextNode(name));
+                sp2.appendChild(document.createTextNode(networks[nid].networktype));
+                li.setAttribute('id', name);
+                li.setAttribute('value', String(nid));
+                li.appendChild(sp1);
+                li.appendChild(sp2);
+                li.onclick = function () {
+                    flux.fitData(li.value)
+                };
+                ul.appendChild(li);
+            }
         }
     }
 
     public removeGraphData(gid : number){
         let GD = graphDatasets[gid];
-        let ul = document.getElementById("datalist");
-        let name = "Dataset: " + GD.label + " Format: " + GD.datatype;
-        let li = document.getElementById(name);
-        ul.removeChild(li);
+        let name = "Dataset: " + GD.label + " Format: " + GD.oDatatype;
+        let elementExists = !!document.getElementById(name); // boolean return if element exists
+        if(elementExists) {
+            let ul = document.getElementById("datalist");
+            let li = document.getElementById(name);
+            ul.removeChild(li);
+        }
     }
 
     public removeNetworkData(nid : number){
@@ -700,10 +726,11 @@ class graphData {
     label: string;
     data: number[];
     xdata: number[];
-    datatype: string;
-    units: string;
+    datatype: string; // rmsf or bfactor
+    units: string; // A_sqr or nm_sqr
     gammaSim: number; // Spring force constant only used if graphData is generated as a Fit
     cutoff: number; // Cutoff (A) for edges, only used if graphData is generated as a Fit
+    oDatatype: string; // Stores (original datatype) for the labels on the Fluctuation window (used in UI-> view)
     constructor(l, d, x, dt, u){
         this.label = l;
         this.data = d;
@@ -712,6 +739,7 @@ class graphData {
         this.units = u;
         this.gammaSim = 0;
         this.cutoff = 0;
+        this.oDatatype = this.datatype;
     };
     convertType(format:string) {
         if(['rmsf', 'bfactor'].indexOf(format) < 0) return; // TODO: Add error throw here and convertUnits

--- a/ts/editing/editing.ts
+++ b/ts/editing/editing.ts
@@ -246,7 +246,7 @@ function deleteNetworkWrapper(nid: number) {
 
 function fillEdgesWrapper(nid: number, edgecase: number) {
     // Easy expansion for other edge methods
-    if(networks.length == 0) {
+    if(networks.length == 0 || nid < 0) {
         notify('No Networks Found, Please Create Network');
     } else {
         let net = networks[nid];
@@ -258,6 +258,9 @@ function fillEdgesWrapper(nid: number, edgecase: number) {
                 } else {
                     net.edgesByCutoff(cutoff);
                 }
+                break;
+            case 1:
+                net.edgesMWCENM();
         }
     }
 }

--- a/ts/file_handling/file_reading.ts
+++ b/ts/file_handling/file_reading.ts
@@ -93,7 +93,7 @@ function handleFiles(files: FileList) {
         else if (ext === "top") topFile = files[i];
         else if (ext === "json") jsonFile = files[i];
         else if (ext === "txt" && (fileName.includes("trap") || fileName.includes("force") )) trapFile = files[i];
-        else if (ext === "pdb") {
+        else if (ext === "pdb" || ext === "pdb1" || ext === "pdb2") {
             notify("Reading PDB File...");
             pdbfile = files[i];
             readPdbFile(pdbfile);
@@ -935,13 +935,17 @@ function prep_pdb(pdblines: string[]){
     // Other Info for MWCENM
     let dsbonds = [];
 
+    let start = 0;  // sometimes the end of a chain is saved into a different file, ignoring any garbage like that
+    if(pdblines[0].substr(0, 3) == "TER"){
+        start = 1;
+    }
+
     // Find Chain Termination statements TER and uses
-    for(let i = 0; i< pdblines.length; i++){
+    for(let i = start; i< pdblines.length; i++){
         if(pdblines[i].substr(0, 4) == 'ATOM' && noatom==false){
             firstatom = i;
             noatom = true;
         }
-
         if (pdblines[i].substr(0, 3) === 'TER'){
             chainDivs.push(i);
         } else if(pdblines[i].substr(0, 6) === 'ENDMDL'){
@@ -951,6 +955,8 @@ function prep_pdb(pdblines: string[]){
             // disulphide bond info: residue 1 chain id, res 1 res num, res2 chain id, res 2 res num
             let dbond = [line.substring(15, 17).trim(), parseInt(line.substring(17, 21).trim()), line.substring(29, 31).trim(), parseInt(line.substring(31, 35).trim())];
             dsbonds.push(dbond);
+        } else if(pdblines[i].substr(0, 3) === 'END'){ // sometimes people don't end their chain with a TER statement
+            chainDivs.push(i);
         }
     }
 
@@ -977,17 +983,22 @@ function prep_pdb(pdblines: string[]){
     })
 
     let nchainids : string[] = []; // Store new chainids
-    let alphabet = 'abcdefghijklmnopqrstuvwxyz123456789<>?/!@#$%^&*()_-=+'.split('');
-
+    let fullalpha = []
+    let lastindex = 1; //
+    let alphabet = 'a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.1.2.3.4.5.6.7.8.9.<.>.?./.!.@.#.$.%.^.&.*.(.)._.-.=.+'.split('.');
+    fullalpha = fullalpha.concat(alphabet);
+    // supports 2862 chains with the same chain id in the same pdb file
+    alphabet.forEach((id, idx, arr) => fullalpha = fullalpha.concat(arr.map(x => {return id+x;})));
     sorted_repeated_chainids.forEach((val, ind) => {
         if(nchainids.indexOf(val) != ind){ //same chain identifier needs to be fixed
             if(val != "" && val.includes("*")){ //unique chain
                 let nval = val;
-                let attmpt_indx = 1;
-                while(nchainids.indexOf(nval) != -1){
-                    nval = alphabet[attmpt_indx] + val;
+                let attmpt_indx = lastindex;
+                while(nchainids.indexOf(nval) != -1 && attmpt_indx < 2862){
+                    nval = fullalpha[attmpt_indx] + val;
                     attmpt_indx += 1;
                 }
+                lastindex = attmpt_indx;
                 nchainids.push(nval);
             } else {
                 nchainids.push(val);
@@ -1738,26 +1749,32 @@ function addPDBToScene () {
                 let pdbres3to5 = nstrand.residues.reverse(); // Flipped Order so it reads 3'  to 5'
                 for (let j = 0; j < nstrand.residues.length; j++) {
                     //For getting center of mass
-                    let info = CalcInfoNC(pdbres3to5[j]);
-                    initInfo.push(info);
-                    strandInfo.push(info);
-                    com.add(info[2]); //Add position to COM calc
+                    try{
+                        let info = CalcInfoNC(pdbres3to5[j]);
+                        initInfo.push(info);
+                        strandInfo.push(info);
+                        com.add(info[2]); //Add position to COM calc
 
-                    let nc = currentStrand.createBasicElement(nextElementId);
-                    nc.n3 = null;
-                    nc.n5 = null;
-                    nc.sid = nextElementId - oldElementId;
-                    bFactors.push(info[5]);
-                    xdata.push(nc.sid);
-                    if (j != 0) {
-                        let prevnc = elements.get(nextElementId - 1); //Get previous Element
-                        nc.n3 = prevnc;
-                        prevnc.n5 = nc;
+                        let nc = currentStrand.createBasicElement(nextElementId);
+                        nc.n3 = null;
+                        nc.n5 = null;
+                        nc.sid = nextElementId - oldElementId;
+                        bFactors.push(info[5]);
+                        xdata.push(nc.sid);
+                        if (j != 0) {
+                            let prevnc = elements.get(nextElementId - 1); //Get previous Element
+                            nc.n3 = prevnc;
+                            prevnc.n5 = nc;
+                        }
+                        elements.push(nc);
+                        nextElementId++;
+                    } catch (e) {
+                        notify("Nucleotide could not be initialized");
                     }
-                    elements.push(nc);
-                    nextElementId++;
+
                 }
                 currentStrand.updateEnds();
+
 
                 // Take care of repeats Access by Chain Identifier
                 initlist.repeatIDs.forEach((rid, indx) => {
@@ -1766,25 +1783,29 @@ function addPDBToScene () {
                         currentStrand.getMonomers(true).forEach((mon, mid) => {
                             let repeatNuc = repeatStrand.createBasicElement(nextElementId);
                             repeatNuc.sid = nextElementId - oldElementId;
-                            let rinfo = strandInfo[mid].slice(); // copy originals initialization info
-                            let rotquat = initlist.repeatQuatRots[indx];
-                            rinfo[3] = rinfo[3].applyQuaternion(rotquat) // Rotate a1
-                            rinfo[4] = rinfo[4].applyQuaternion(rotquat) // Rotate a3
-                            rinfo[2] = initlist.repeatCoords[indx][mid]; // New Position
-                            bFactors.push(rinfo[5]) // Assume same B factors
-                            xdata.push(repeatNuc.sid)
-                            com.add(rinfo[2])
-                            initInfo.push(rinfo);
-                            repeatNuc.n3 = null;
-                            repeatNuc.n5 = null;
-                            // monomers go 5' to 3'
-                            if (mid != 0) {
-                                let prevaa = elements.get(nextElementId - 1); //Get previous Element
-                                repeatNuc.n3 = prevaa;
-                                prevaa.n5 = repeatNuc;
+                            try {
+                                let rinfo = strandInfo[mid].slice(); // copy originals initialization info
+                                let rotquat = initlist.repeatQuatRots[indx];
+                                rinfo[3] = rinfo[3].applyQuaternion(rotquat) // Rotate a1
+                                rinfo[4] = rinfo[4].applyQuaternion(rotquat) // Rotate a3
+                                rinfo[2] = initlist.repeatCoords[indx][mid]; // New Position
+                                bFactors.push(rinfo[5]) // Assume same B factors
+                                xdata.push(repeatNuc.sid)
+                                com.add(rinfo[2])
+                                initInfo.push(rinfo);
+                                repeatNuc.n3 = null;
+                                repeatNuc.n5 = null;
+                                // monomers go 5' to 3'
+                                if (mid != 0) {
+                                    let prevaa = elements.get(nextElementId - 1); //Get previous Element
+                                    repeatNuc.n3 = prevaa;
+                                    prevaa.n5 = repeatNuc;
+                                }
+                                elements.push(repeatNuc);
+                                nextElementId++;
+                            } catch (e) {
+                                notify("Nucleotide could not be initialized");
                             }
-                            elements.push(repeatNuc);
-                            nextElementId++;
                         });
                         repeatStrand.updateEnds();
                     }
@@ -1795,6 +1816,7 @@ function addPDBToScene () {
         com.divideScalar(sys.systemLength());
         let pdbBfactors = new graphData(label, bFactors, xdata, "bfactor", "A_sqr");
         graphDatasets.push(pdbBfactors);
+        if(flux.fluxWindowOpen) view.addGraphData(graphDatasets.length-1); // add to flux window if open, otherwise it'll be added on next opening
 
         sys.initInstances(sys.systemLength())
         // This Function calculates all necessary info for an Amino Acid in PDB format and writes it to the system
@@ -1815,16 +1837,23 @@ function addPDBToScene () {
         let xpos = initInfo.map((info) => {return info[2].x;});
         let ypos = initInfo.map((info) => {return info[2].y;});
         let zpos = initInfo.map((info) => {return info[2].z;});
-        let xdim= (Math.max(...xpos) - Math.min(...xpos)) * 1.5;
-        let ydim= (Math.max(...ypos) - Math.min(...ypos)) * 1.5;
-        let zdim= (Math.max(...zpos) - Math.min(...zpos)) * 1.5;
+        //built in Math.min and Math.max crash the program once xpos, ypos, and zpos reach a high length (N=300000 was my test case)
+        let xmax = xpos.reduce((a,b) => {return Math.max(a, b)})
+        let xmin = xpos.reduce((a,b) => {return Math.min(a, b)})
+        let ymax = ypos.reduce((a,b) => {return Math.max(a, b)})
+        let ymin = ypos.reduce((a,b) => {return Math.min(a, b)})
+        let zmax = zpos.reduce((a,b) => {return Math.max(a, b)})
+        let zmin = zpos.reduce((a,b) => {return Math.min(a, b)})
+        let xdim= xmax - xmin;
+        let ydim= ymax - ymin;
+        let zdim= zmax - zmin;
         if(xdim < 2) xdim = 2.5;
         if(ydim < 2) ydim = 2.5;
         if(zdim < 2) zdim = 2.5;
 
-        if(box.x < xdim) box.x = xdim;
-        if(box.y < ydim) box.y = ydim;
-        if(box.z < zdim) box.z = zdim;
+        if(box.x < xdim) box.x = xdim*1.25;
+        if(box.y < ydim) box.y = ydim*1.25;
+        if(box.z < zdim) box.z = zdim*1.25;
         redrawBox();
 
         // Second Loop Going through Exactly the same way

--- a/ts/model/aminoAcid.ts
+++ b/ts/model/aminoAcid.ts
@@ -6,6 +6,7 @@
 class AminoAcid extends BasicElement {
     a1: THREE.Vector3;
     a3: THREE.Vector3;
+    pdbindices: [number, any, any];
 
     constructor(id: number, strand: Strand) {
         super(id, strand);
@@ -13,6 +14,10 @@ class AminoAcid extends BasicElement {
         this.a1 = new THREE.Vector3(0.,0.,0.);
         this.a3 = new THREE.Vector3(0.,0.,0.);
     };
+
+    setPDBIndices(datasetindx, chainid, pdbresnum){
+        this.pdbindices = [datasetindx, chainid, pdbresnum];
+    }
 
     elemToColor(elem: number | string): THREE.Color {
         elem = { "K": 0, "C": 1, "A": 2, "T": 3, "E": 3, "S": 4, "D": 5, "N": 6, "Q": 7, "H": 8, "G": 10, "P": 11, "R": 12, "V": 13, "I": 14, "L": 15, "M": 16, "F": 17, "Y": 18, "W": 19 }[elem];

--- a/ts/model/aminoAcid.ts
+++ b/ts/model/aminoAcid.ts
@@ -17,7 +17,7 @@ class AminoAcid extends BasicElement {
 
     setPDBIndices(datasetindx, chainid, pdbresnum){
         this.pdbindices = [datasetindx, chainid, pdbresnum];
-    }
+    };
 
     elemToColor(elem: number | string): THREE.Color {
         elem = { "K": 0, "C": 1, "A": 2, "T": 3, "E": 3, "S": 4, "D": 5, "N": 6, "Q": 7, "H": 8, "G": 10, "P": 11, "R": 12, "V": 13, "I": 14, "L": 15, "M": 16, "F": 17, "Y": 18, "W": 19 }[elem];

--- a/ts/model/basicElement.ts
+++ b/ts/model/basicElement.ts
@@ -19,7 +19,7 @@ abstract class BasicElement {
     clusterId: number;
     dummySys: System;
     color: THREE.Color;
-    pdbid: string; //Only Intialized if loaded from a PDB structure
+    // pdbid: string; //Only Intialized if loaded from a PDB structure
 
     constructor(id: number, strand: Strand) {
         this.id = id;

--- a/ts/model/network.ts
+++ b/ts/model/network.ts
@@ -162,6 +162,7 @@ class Network {
     ;
     sendtoUI(){
         this.fittingReady = true;
+        if(flux.fluxWindowOpen) view.addNetworkData(this.nid);
     }
     ;
     fillVec(vecName, unitSize, pos, vals) {
@@ -287,6 +288,7 @@ class Network {
         // network is ready for solving and visualization
         this.networktype = "MWCENM";
         if(this.reducedEdges.total != 0) {
+            // this.reducedEdges.ks = this.reducedEdges.ks.map(x => 10*x) // mwcenm isn't super great
             this.initInstances(this.reducedEdges.total);
             this.initEdges();
             this.prepVis();
@@ -331,6 +333,8 @@ class Network {
     }
     addNonpolarBonds(){
         let nonpolark = 1.0;
+
+        let np = 12;
 
         // checks for atoms within 4 residues of one another on two amino acids
         // let nonpolarcheck = function(res1, res2){ // looks for pairs of atoms from different residues within 4 Angstroms
@@ -477,7 +481,10 @@ class Network {
                 let qind = this.particles.indexOf(p.n3);
                 if (qind != -1) {
                     notify("backbone Bond " + i.toString() + " " + qind.toString());
-                    this.reducedEdges.addEdge(qind, i, this.elemcoords.distance(i, qind), 's', covalentk);
+                    let dis = this.elemcoords.distance(i, qind);
+                    if(dis < 1){ // removes any obviously incorrect backbone bonds
+                        this.reducedEdges.addEdge(qind, i, this.elemcoords.distance(i, qind), 's', covalentk);
+                    }
                 }
             }
         }

--- a/ts/model/network.ts
+++ b/ts/model/network.ts
@@ -20,6 +20,7 @@ class Edges { //Edges connect particles, for now these represent spring potentia
         this.extraParams = [];
     }
     addEdge(id1: number, id2: number, eqdist:number, type:string, k: number =1, xparams: any[] = []) {
+        if(id1 == id2) return; // Can't Add Edge to Itself
         let ind = this.checkEdge(id1, id2, eqdist);
         if(ind > 0){
             this.ks[ind] += k; // additive spring constants, I did this for MWCENM hopefully it doesn't bite me later
@@ -27,7 +28,7 @@ class Edges { //Edges connect particles, for now these represent spring potentia
             if (id1 < id2) {
                 this.p1.push(id1);
                 this.p2.push(id2);
-            } else if (id2 > id1) {
+            } else if (id1 > id2) {
                 this.p1.push(id2);
                 this.p2.push(id1);
             }

--- a/ts/model/network.ts
+++ b/ts/model/network.ts
@@ -20,21 +20,21 @@ class Edges { //Edges connect particles, for now these represent spring potentia
         this.extraParams = [];
     }
     addEdge(id1: number, id2: number, eqdist:number, type:string, k: number =1, xparams: any[] = []) {
-        if (id1 < id2) {
-            this.p1.push(id1);
-            this.p2.push(id2);
+        let ind = this.checkEdge(id1, id2, eqdist);
+        if(ind > 0){
+            this.ks[ind] += k; // additive spring constants, I did this for MWCENM hopefully it doesn't bite me later
+        } else {
+            if (id1 < id2) {
+                this.p1.push(id1);
+                this.p2.push(id2);
+            } else if (id2 > id1) {
+                this.p1.push(id2);
+                this.p2.push(id1);
+            }
             this.ks.push(k);
             this.types.push(type);
             this.eqDist.push(eqdist);
             this.extraParams.push(xparams);
-            this.total += 1;
-        } else if (id2 > id1) {
-            this.p1.push(id2);
-            this.p2.push(id1);
-            this.ks.push(k);
-            this.eqDist.push(eqdist);
-            this.extraParams.push(xparams);
-            this.types.push(type);
             this.total += 1;
         }
     };
@@ -53,6 +53,17 @@ class Edges { //Edges connect particles, for now these represent spring potentia
             }
         }
     };
+    checkEdge(id1: number, id2: number, eqdist:number){ // if edge exist returns index, else returns -1
+        let dist = this.eqDist.indexOf(eqdist);
+        if(dist > -1) {
+            if((this.p1[dist] == id1 && this.p2[dist] == id2) || (this.p2[dist] == id1 && this.p1[dist] == id2)){
+                return dist;
+            }
+        } else {
+            return dist;
+        }
+    }
+    ;
     clearAll(){
         this.p1 = [];
         this.p2 = [];
@@ -289,7 +300,7 @@ class Network {
             // let chains = pdbFileInfo[ud].pdbsysinfo;
 
             let p1, p2; // will be refences to corresponding particles
-            let p1found, p2found; // bool indica
+            let p1found, p2found; // bools
             let hbondk = 100; // strength of h bond
             hbonds.forEach((hb, hid) => {
                 p1found = false;
@@ -397,7 +408,7 @@ class Network {
             let makesaltbridge=false;
             posatoms.forEach(pa => {
                 negatoms.forEach(na => {
-                    if(pdbdist(pa, na) < 4){ // 4 A is the cutoff used in the original MWCENM paper
+                    if(pdbdist(pa, na) < 4/8.518){ // 4 A is the cutoff used in the original MWCENM paper
                         makesaltbridge=true;
                     }
                 })

--- a/windows/fluctuationWindow.html
+++ b/windows/fluctuationWindow.html
@@ -1,48 +1,69 @@
 <div>
-    <div class="dropdown-button">
-        <button class="button dropdown-toggle">Graph Type</button>
-        <ul class="d-menu put-left" data-role="dropdown">
-            <li onclick="flux.changeType('bfactor')">B-factor</li>
-            <li onclick="flux.changeType('rmsf')">RMSF</li>
-        </ul>
-    </div>
-    <div class="dropdown-button">
-        <button class="button dropdown-toggle">Units</button>
-        <ul class="d-menu put-left" data-role="dropdown">
-            <li onclick="flux.changeUnits('A_sqr')">A^2</li>
-            <li onclick="flux.changeUnits('nm_sqr')">nm^2</li>
-        </ul>
-    </div>
-    <button class="button primary outline" id="sidetoggle" onclick="view.toggleSideBarDatasets()">Data & Options</button>
 
-    <button class="button secondary" onclick="flux.downloadChart()" ><span class="mif-floppy-disk"></span></button>
-    <button class="button dark" onclick="flux.applyCurrentIndx('avg')">Apply Indexing</button>
-    <button class="button dark" onclick="flux.downloadGraphDatasets()">Download Datasets</button>
+    <div class="group">
+        <div class="group" style="display: block">
+            <div style="float: left; width: 85%">
+                <input id="fluxfile"  type="file" data-role="file" data-prepend="Data Files" data-cls-caption="bg-white fg-blue"
+                   data-cls-button="bg-darkBlue fg-white" multiple accept=".json">
+            </div>
+            <div style="float: right; width: 15%">
+                <button class="button primary outline" id="submit" onclick="flux.loadFluxData()">Load Files</button>
+            </div>
+        </div>
+
+        <div class="dropdown-button">
+            <button class="button dropdown-toggle">Graph Type</button>
+            <ul class="d-menu put-left" data-role="dropdown">
+                <li onclick="flux.changeType('bfactor')">B-factor</li>
+                <li onclick="flux.changeType('rmsf')">RMSF</li>
+            </ul>
+        </div>
+        <div class="dropdown-button">
+            <button class="button dropdown-toggle">Units</button>
+            <ul class="d-menu put-left" data-role="dropdown">
+                <li onclick="flux.changeUnits('A_sqr')">A^2</li>
+                <li onclick="flux.changeUnits('nm_sqr')">nm^2</li>
+            </ul>
+        </div>
+
+
+        <!--    <button class="button primary outline" id="sidetoggle" onclick="view.toggleSideBarDatasets()">Data & Options</button>-->
+
+        <button class="button secondary" onclick="flux.downloadChart()" ><span class="mif-floppy-disk"></span></button>
+        <button class="button dark" onclick="flux.applyCurrentIndx('avg')">Apply Indexing</button>
+        <button class="button dark" onclick="flux.downloadGraphDatasets()">Download Datasets</button>
+
+
+    </div>
+
 
 </div>
 
-<aside id="fluxbar" class="sidebar" data-role="sidebar" data-toggle="#sidetoggle">
-    <div class="sidebar-header">
-        <div class="title">Network Fluctuation Solver</div>
-<!--        <div class="caption">First Select a Data Source to fit to then a network to fit to</div>-->
-        <div>
-<!--            <div class="caption">Temperature at which fluctuation data was obtained is mandatory</div>-->
-            <label for="temp">Temperature (K)</label><input id="temp" type="text" data-role="input" data-default-value="300" onclick="flux.setTemp(view.getInputNumber('temp'))">
-        </div>
 
-    </div>
-    <div class="sidebar-content">
+
+
+<!--<aside id="fluxbar" class="sidebar" data-role="sidebar" data-toggle="#sidetoggle">-->
+<!--    <div class="sidebar-header">-->
+<!--        <div class="title">Network Fluctuation Solver</div>-->
+<!--&lt;!&ndash;        <div class="caption">First Select a Data Source to fit to then a network to fit to</div>&ndash;&gt;-->
+<!--        <div>-->
+<!--&lt;!&ndash;            <div class="caption">Temperature at which fluctuation data was obtained is mandatory</div>&ndash;&gt;-->
+<!--            <label for="temp">Temperature (K)</label><input id="temp" type="text" data-role="input" data-default-value="300" onclick="flux.setTemp(view.getInputNumber('temp'))">-->
+<!--        </div>-->
+
+<!--    </div>-->
+<!--    <div class="sidebar-content">-->
 <!--        <div class="title" >Select or Load Target Data</div>-->
-        <button class="button" id="collapse_toggle_3">Available Datasets</button>
-        <div data-role="collapse" data-toggle-element="#collapse_toggle_3">
-            <!--        dynamically List Data Here -->
-            <ul class="items-list" id="datalist"></ul>
-        </div>
-<!--        networks Added in view.toggleSideBarDatasets-->
-        <button class="button" id="collapse_toggle_1">Fitting Ready Networks</button>
-        <div class="pos-relative">
-            <ul class="items-list" id="readynetlist" data-role="collapse" data-toggle-element="#collapse_toggle_1"></ul>
-        </div>
+<!--        <button class="button" id="collapse_toggle_3">Available Datasets</button>-->
+<!--        <div data-role="collapse" data-toggle-element="#collapse_toggle_3">-->
+<!--            &lt;!&ndash;        dynamically List Data Here &ndash;&gt;-->
+<!--            <ul class="items-list" id="datalist"></ul>-->
+<!--        </div>-->
+<!--&lt;!&ndash;        networks Added in view.toggleSideBarDatasets&ndash;&gt;-->
+<!--        <button class="button" id="collapse_toggle_1">Fitting Ready Networks</button>-->
+<!--        <div class="pos-relative">-->
+<!--            <ul class="items-list" id="readynetlist" data-role="collapse" data-toggle-element="#collapse_toggle_1"></ul>-->
+<!--        </div>-->
 
 <!--        This section may be used later, however, since we are still dependent on the Python Scripts-->
 <!--        for solving large networks it is of little use currently-->
@@ -65,24 +86,67 @@
 <!--            </ul>-->
 <!--            </div>-->
 
-            <input id="fluxfile"  type="file" data-role="file" data-prepend="Data Files" data-cls-caption="bg-blue fg-white"
-                   data-cls-button="bg-darkBlue fg-white" multiple accept=".json">
-            <button class="button primary outline" id="submit" onclick="flux.loadFluxData()">Load Files</button>
+<!--            <input id="fluxfile"  type="file" data-role="file" data-prepend="Data Files" data-cls-caption="bg-blue fg-white"-->
+<!--                   data-cls-button="bg-darkBlue fg-white" multiple accept=".json">-->
+<!--            <button class="button primary outline" id="submit" onclick="flux.loadFluxData()">Load Files</button>-->
 <!--            accept="flux/json"-->
 <!--            <sub>* .json files as outputted by oxDNA_Analysis_tools</sub>-->
-        </div>
+<!--        </div>-->
 <!--        <div class="input-control file" data-role="input">-->
 <!--            <input type="file">-->
 <!--            <button class="button"><span class="mif-folder"></span></button>-->
 <!--        </div>-->
-    </div>
-</aside>
+<!--    </div>-->
+<!--</aside>-->
 
 <!--<div class="tiles-group" id="tileg">-->
 <!--    <div data-role="tile" data-size="small">-->
 <!--        <span class="branding-bar">Add Data</span>-->
 <!--    </div>-->
 <!--</div>-->
-<div>
-    <canvas id="flux" style="display: block; width: 850px; height: 300px;" class="chartjs-render-monitor"></canvas>
+<div style="display: flex">
+    <div class="group" style="float:left; width: 75%;">
+        <canvas id="flux" style="display: block; width: 100%; height: 300px;" class="chartjs-render-monitor"></canvas>
+    </div>
+    <div class="group" style="float:right; width:25%;">
+        <div>
+            <!--            <div class="caption">Temperature at which fluctuation data was obtained is mandatory</div>-->
+            <label for="temp">Temperature (K)</label><input id="temp" type="text" data-role="input" data-default-value="300" onclick="flux.setTemp(view.getInputNumber('temp'))">
+        </div>
+        <button class="button" id="collapse_toggle_3">Available Datasets</button>
+        <div data-role="collapse" data-toggle-element="#collapse_toggle_3">
+            <!--        dynamically List Data Here -->
+            <ul class="items-list" id="datalist"></ul>
+        </div>
+        <!--        networks Added in view.toggleSideBarDatasets-->
+        <button class="button" id="collapse_toggle_1">Fitting Ready Networks</button>
+        <div class="pos-relative">
+            <ul class="items-list" id="readynetlist" data-role="collapse" data-toggle-element="#collapse_toggle_1"></ul>
+        </div>
+    </div>
 </div>
+
+
+
+<!--<div class="group" style="float:right; width:25%;">-->
+<!--    <div class="dropdown-button">-->
+<!--        <button class="button dropdown-toggle">Graph Type</button>-->
+<!--        <ul class="d-menu put-left" data-role="dropdown">-->
+<!--            <li onclick="flux.changeType('bfactor')">B-factor</li>-->
+<!--            <li onclick="flux.changeType('rmsf')">RMSF</li>-->
+<!--        </ul>-->
+<!--    </div>-->
+<!--    <div class="dropdown-button">-->
+<!--        <button class="button dropdown-toggle">Units</button>-->
+<!--        <ul class="d-menu put-left" data-role="dropdown">-->
+<!--            <li onclick="flux.changeUnits('A_sqr')">A^2</li>-->
+<!--            <li onclick="flux.changeUnits('nm_sqr')">nm^2</li>-->
+<!--        </ul>-->
+<!--    </div>-->
+<!--    <button class="button primary outline" id="sidetoggle" onclick="view.toggleSideBarDatasets()">Data & Options</button>-->
+
+<!--    <button class="button secondary" onclick="flux.downloadChart()" ><span class="mif-floppy-disk"></span></button>-->
+<!--    <button class="button dark" onclick="flux.applyCurrentIndx('avg')">Apply Indexing</button>-->
+<!--    <button class="button dark" onclick="flux.downloadGraphDatasets()">Download Datasets</button>-->
+<!--</div>-->
+

--- a/windows/fluctuationWindow.json
+++ b/windows/fluctuationWindow.json
@@ -2,6 +2,8 @@
     "resizable": true,
     "place": "bottom-right",
     "title": "Fluctuation Window",
-    "width": 900,
-    "height": 400
+    "width": 600,
+    "height": 500,
+    "data-role": "window",
+    "data-btn-close": false
 }

--- a/windows/fluctuationWindow.json
+++ b/windows/fluctuationWindow.json
@@ -4,6 +4,8 @@
     "title": "Fluctuation Window",
     "width": 600,
     "height": 500,
+    "btnClose": false,
     "data-role": "window",
-    "data-btn-close": false
+    "clsCaption": "bg-red",
+    "clsContent": "bg-white fg-red"
 }


### PR DESCRIPTION
1. Added Support for PDB files that do not declare any chains, but do have models (seems a little niche use, but needed to parse output from Modeller pdb files)

2. Fluctuation Window no longer has that terrible aside bar. Reformatting required the file loading to go to the top of the fluctuation window.

3. Fixed Fluctuation Window dataset loading by removing close button and adding some error checking on the network and graph data loaders (in view global) 