### PR TITLE
Patchy particle visualisation updates

### DIFF
--- a/dist/UI/UI.js
+++ b/dist/UI/UI.js
@@ -678,7 +678,12 @@ class View {
     showHoverInfo(pos, e) {
         let hoverInfo = document.getElementById('hoverInfo');
         let color = e.elemToColor(e.type).getHexString();
-        hoverInfo.innerHTML = `<span style="background:#${color}4f; padding: 5px">${e.type} ${e.getSystem().id}:${e.strand.id}:${e.id}</span>`;
+        if (e.isPatchyParticle()) {
+            hoverInfo.innerHTML = `<span style="background:#${color}4f; padding: 5px">${e.type} ${e.getSystem().id}:${e.id}</span>`;
+        }
+        else {
+            hoverInfo.innerHTML = `<span style="background:#${color}4f; padding: 5px">${e.type} ${e.getSystem().id}:${e.strand.id}:${e.id}</span>`;
+        }
         hoverInfo.style.left = pos.x + 'px';
         hoverInfo.style.top = pos.y + 20 + 'px';
         hoverInfo.hidden = false;

--- a/dist/UI/base_selector.js
+++ b/dist/UI/base_selector.js
@@ -141,12 +141,14 @@ function updateView(sys) {
     selectedBases.forEach((base) => {
         //store global ids for BaseList view
         listBases.push(base.id);
-        //assign each of the selected bases to a strand
-        let strandID = base.strand.id;
-        if (strandID in baseInfoStrands)
-            baseInfoStrands[strandID].push(base);
-        else
-            baseInfoStrands[strandID] = [base];
+        if (!base.isPatchyParticle) {
+            //assign each of the selected bases to a strand
+            let strandID = base.strand.id;
+            if (strandID in baseInfoStrands)
+                baseInfoStrands[strandID].push(base);
+            else
+                baseInfoStrands[strandID] = [base];
+        }
     });
     // Display every selected nucleotide id (top txt box)
     makeTextArea(listBases.join(","), "baseList");

--- a/dist/UI/keybindings.js
+++ b/dist/UI/keybindings.js
@@ -25,6 +25,14 @@ canvas.addEventListener("keydown", event => {
             if (event.ctrlKey || event.metaKey) {
                 cutWrapper();
             }
+            else {
+                if (event.shiftKey) {
+                    shiftWithinBox(new THREE.Vector3(-1, 0, 0));
+                }
+                else {
+                    shiftWithinBox(new THREE.Vector3(1, 0, 0));
+                }
+            }
             break;
         case 'v':
             if (event.ctrlKey || event.metaKey) {
@@ -53,10 +61,26 @@ canvas.addEventListener("keydown", event => {
                     editHistory.undo();
                 }
             }
+            else {
+                if (event.shiftKey) {
+                    shiftWithinBox(new THREE.Vector3(0, 0, -1));
+                }
+                else {
+                    shiftWithinBox(new THREE.Vector3(0, 0, 1));
+                }
+            }
             break;
         case 'y':
             if (event.ctrlKey || event.metaKey) {
                 editHistory.redo();
+            }
+            else {
+                if (event.shiftKey) {
+                    shiftWithinBox(new THREE.Vector3(0, -1, 0));
+                }
+                else {
+                    shiftWithinBox(new THREE.Vector3(0, 1, 0));
+                }
             }
             break;
         // Select everything not selected:

--- a/dist/api/scene_api.js
+++ b/dist/api/scene_api.js
@@ -190,7 +190,7 @@ var api;
      * Show the specified element in the viewport
      * @param element Element to center view at
      */
-    function findElement(element, steps = 50) {
+    function findElement(element, steps = 20) {
         let targetPos;
         if (element.isNucleotide()) {
             targetPos = element.getInstanceParameter3('bbOffsets');

--- a/dist/api/scene_api.js
+++ b/dist/api/scene_api.js
@@ -190,14 +190,33 @@ var api;
      * Show the specified element in the viewport
      * @param element Element to center view at
      */
-    function findElement(element) {
-        let targetPos = element.getInstanceParameter3('bbOffsets');
+    function findElement(element, steps = 50) {
+        let targetPos;
+        if (element.isNucleotide()) {
+            targetPos = element.getInstanceParameter3('bbOffsets');
+        }
+        else {
+            targetPos = element.getPos();
+        }
         // Target trackball controls at element position
-        controls.target = targetPos;
+        //controls.target = targetPos;
         // Move in close to the element
-        let targetDist = 3;
+        let targetDist = 10;
         let dist = (camera.position.distanceTo(targetPos));
-        camera.position.lerp(targetPos, 1 - (targetDist / dist));
+        let endPos = camera.position.clone().sub(targetPos).setLength(targetDist).add(targetPos);
+        if (steps > 1) {
+            camera.position.lerp(endPos, 1 / steps);
+            controls.target.lerp(targetPos, 1 / steps);
+        }
+        else {
+            camera.position.lerp(endPos, 1 - (targetDist / dist));
+            controls.target = targetPos;
+        }
+        if (steps > 1) {
+            requestAnimationFrame(() => {
+                api.findElement(element, steps - 1);
+            });
+        }
     }
     api.findElement = findElement;
     function selectElements(elems, keepPrevious) {

--- a/dist/editing/translation.js
+++ b/dist/editing/translation.js
@@ -23,49 +23,61 @@ function rotateElementsByQuaternion(elements, q, about, updateScene = true) {
         if (e.dummySys !== null) {
             sys = e.dummySys;
         }
-        //get current positions
-        let cmPos = e.getPos();
-        let bbPos = e.getInstanceParameter3("bbOffsets");
-        let nsPos = e.getInstanceParameter3("nsOffsets");
-        let conPos = e.getInstanceParameter3("conOffsets");
-        let bbconPos = e.getInstanceParameter3("bbconOffsets");
-        //the rotation center needs to be (0,0,0)
-        cmPos.sub(about);
-        bbPos.sub(about);
-        nsPos.sub(about);
-        conPos.sub(about);
-        bbconPos.sub(about);
-        cmPos.applyQuaternion(q);
-        bbPos.applyQuaternion(q);
-        nsPos.applyQuaternion(q);
-        conPos.applyQuaternion(q);
-        bbconPos.applyQuaternion(q);
-        //get current rotations and convert to THREE coordinates
-        let nsRotationV = e.getInstanceParameter4("nsRotation");
-        let nsRotation = glsl2three(nsRotationV);
-        let conRotationV = e.getInstanceParameter4("conRotation");
-        let conRotation = glsl2three(conRotationV);
-        let bbconRotationV = e.getInstanceParameter4("bbconRotation");
-        let bbconRotation = glsl2three(bbconRotationV);
-        //apply individual object rotation
-        nsRotation.multiply(q2);
-        conRotation.multiply(q2);
-        bbconRotation.multiply(q2);
-        //move the object back to its original position
-        cmPos.add(about);
-        bbPos.add(about);
-        nsPos.add(about);
-        conPos.add(about);
-        bbconPos.add(about);
-        //update the instancing matrices
-        sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
-        sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
-        sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);
-        sys.fillVec('conOffsets', 3, sid, [conPos.x, conPos.y, conPos.z]);
-        sys.fillVec('bbconOffsets', 3, sid, [bbconPos.x, bbconPos.y, bbconPos.z]);
-        sys.fillVec('nsRotation', 4, sid, [nsRotation.w, nsRotation.z, nsRotation.y, nsRotation.x]);
-        sys.fillVec('conRotation', 4, sid, [conRotation.w, conRotation.z, conRotation.y, conRotation.x]);
-        sys.fillVec('bbconRotation', 4, sid, [bbconRotation.w, bbconRotation.z, bbconRotation.y, bbconRotation.x]);
+        if (sys.isPatchySystem()) {
+            let p = e.getPos();
+            p.sub(about);
+            p.applyQuaternion(q);
+            let rotation = glsl2three(e.getInstanceParameter4("rotations"));
+            rotation.multiply(q2);
+            p.add(about);
+            sys.fillPatchyVec(parseInt(e.type), 'offsets', 3, e.sid, p.toArray());
+            sys.fillPatchyVec(parseInt(e.type), 'rotations', 4, e.sid, [rotation.w, rotation.z, rotation.y, rotation.x]);
+        }
+        else {
+            //get current positions
+            let cmPos = e.getPos();
+            let bbPos = e.getInstanceParameter3("bbOffsets");
+            let nsPos = e.getInstanceParameter3("nsOffsets");
+            let conPos = e.getInstanceParameter3("conOffsets");
+            let bbconPos = e.getInstanceParameter3("bbconOffsets");
+            //the rotation center needs to be (0,0,0)
+            cmPos.sub(about);
+            bbPos.sub(about);
+            nsPos.sub(about);
+            conPos.sub(about);
+            bbconPos.sub(about);
+            cmPos.applyQuaternion(q);
+            bbPos.applyQuaternion(q);
+            nsPos.applyQuaternion(q);
+            conPos.applyQuaternion(q);
+            bbconPos.applyQuaternion(q);
+            //get current rotations and convert to THREE coordinates
+            let nsRotationV = e.getInstanceParameter4("nsRotation");
+            let nsRotation = glsl2three(nsRotationV);
+            let conRotationV = e.getInstanceParameter4("conRotation");
+            let conRotation = glsl2three(conRotationV);
+            let bbconRotationV = e.getInstanceParameter4("bbconRotation");
+            let bbconRotation = glsl2three(bbconRotationV);
+            //apply individual object rotation
+            nsRotation.multiply(q2);
+            conRotation.multiply(q2);
+            bbconRotation.multiply(q2);
+            //move the object back to its original position
+            cmPos.add(about);
+            bbPos.add(about);
+            nsPos.add(about);
+            conPos.add(about);
+            bbconPos.add(about);
+            //update the instancing matrices
+            sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
+            sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
+            sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);
+            sys.fillVec('conOffsets', 3, sid, [conPos.x, conPos.y, conPos.z]);
+            sys.fillVec('bbconOffsets', 3, sid, [bbconPos.x, bbconPos.y, bbconPos.z]);
+            sys.fillVec('nsRotation', 4, sid, [nsRotation.w, nsRotation.z, nsRotation.y, nsRotation.x]);
+            sys.fillVec('conRotation', 4, sid, [conRotation.w, conRotation.z, conRotation.y, conRotation.x]);
+            sys.fillVec('bbconRotation', 4, sid, [bbconRotation.w, bbconRotation.z, bbconRotation.y, bbconRotation.x]);
+        }
     });
     if (updateScene) {
         // Update backbone connections for bases with neigbours outside the selection set
@@ -140,6 +152,7 @@ function translateElements(elements, v) {
         }
         if (sys.isPatchySystem()) {
             let p = e.getPos();
+            p.add(v);
             sys.fillPatchyVec(parseInt(e.type), 'offsets', 3, e.sid, p.toArray());
         }
         else {

--- a/dist/editing/translation.js
+++ b/dist/editing/translation.js
@@ -138,21 +138,27 @@ function translateElements(elements, v) {
         if (e.dummySys !== null) {
             sys = e.dummySys;
         }
-        let cmPos = e.getPos();
-        let bbPos = e.getInstanceParameter3("bbOffsets");
-        let nsPos = e.getInstanceParameter3("nsOffsets");
-        let conPos = e.getInstanceParameter3("conOffsets");
-        let bbconPos = e.getInstanceParameter3("bbconOffsets");
-        cmPos.add(v);
-        bbPos.add(v);
-        nsPos.add(v);
-        conPos.add(v);
-        bbconPos.add(v);
-        sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
-        sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
-        sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);
-        sys.fillVec('conOffsets', 3, sid, [conPos.x, conPos.y, conPos.z]);
-        sys.fillVec('bbconOffsets', 3, sid, [bbconPos.x, bbconPos.y, bbconPos.z]);
+        if (sys.isPatchySystem()) {
+            let p = e.getPos();
+            sys.fillPatchyVec(parseInt(e.type), 'offsets', 3, e.sid, p.toArray());
+        }
+        else {
+            let cmPos = e.getPos();
+            let bbPos = e.getInstanceParameter3("bbOffsets");
+            let nsPos = e.getInstanceParameter3("nsOffsets");
+            let conPos = e.getInstanceParameter3("conOffsets");
+            let bbconPos = e.getInstanceParameter3("bbconOffsets");
+            cmPos.add(v);
+            bbPos.add(v);
+            nsPos.add(v);
+            conPos.add(v);
+            bbconPos.add(v);
+            sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
+            sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
+            sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);
+            sys.fillVec('conOffsets', 3, sid, [conPos.x, conPos.y, conPos.z]);
+            sys.fillVec('bbconOffsets', 3, sid, [bbconPos.x, bbconPos.y, bbconPos.z]);
+        }
     });
     // Update backbone connections (is there a more clever way to do this than
     // to loop through all? We only need to update bases with neigbours

--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -954,9 +954,10 @@ function addSystemToScene(system) {
         // Patchy particle geometries
         let s = system;
         if (s.species !== undefined) {
-            const patchResolution = 4;
-            const patchWidth = 0.2;
-            const patchAlignWidth = 0.3;
+            const patchResolution = 4; // Number of points defining each patch
+            const patchWidth = 0.2; // Radius of patch "circle"
+            const patchAlignWidth = 0.3; // Widest radius of patch circle
+            // (indicating patch alignment)
             s.patchyGeometries = s.offsets.map((_, i) => {
                 let g = new THREE.InstancedBufferGeometry();
                 const points = [new THREE.Vector3()];
@@ -971,12 +972,18 @@ function addSystemToScene(system) {
                     const a2 = patch.a2.clone();
                     a2.y *= -1;
                     a2.z *= -1;
-                    for (let i = 0; i < patchResolution; i++) {
-                        let diff = a2.clone().multiplyScalar(i == 0 ? patchAlignWidth : patchWidth);
-                        diff.applyAxisAngle(a1, i * 2 * Math.PI / patchResolution);
-                        points.push(pos.clone().add(diff));
+                    // Too many patches.txt files fail to set a1 and a2 correctly.
+                    if (Math.abs(a1.dot(a2)) > 1e-5) {
+                        console.warn(`The a1 and a2 vectors are incorrectly defined in species ${i}. Using patch position instead`);
+                        points.push(pos.clone());
                     }
-                    console.log(`Patch at ${patch.position.toArray()}`);
+                    else {
+                        for (let i = 0; i < patchResolution; i++) {
+                            let diff = a2.clone().multiplyScalar(i == 0 ? patchAlignWidth : patchWidth);
+                            diff.applyAxisAngle(a1, i * 2 * Math.PI / patchResolution);
+                            points.push(pos.clone().add(diff));
+                        }
+                    }
                 });
                 let particleGeometry = new THREE.ConvexGeometry(points);
                 g.copy(particleGeometry);

--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -953,7 +953,7 @@ function addSystemToScene(system) {
     if (system.isPatchySystem()) {
         let s = system;
         if (s.species !== undefined) {
-            const patchResolution = 32;
+            const patchResolution = 4;
             const patchWidth = 0.2;
             const patchAlignWidth = 0.3;
             s.patchyGeometries = s.offsets.map((_, i) => {
@@ -961,15 +961,14 @@ function addSystemToScene(system) {
                 const points = [new THREE.Vector3()];
                 s.species[i].patches.forEach(patch => {
                     const pos = patch.position.clone();
-                    //pos.x *= -1;
-                    //pos.y *= -1;
-                    //pos.z *= -1;
+                    pos.y *= -1;
+                    pos.z *= -1;
                     const a1 = patch.a1.clone();
-                    //a1.y *= -1;
-                    //a1.z *= -1;
+                    a1.y *= -1;
+                    a1.z *= -1;
                     const a2 = patch.a2.clone();
-                    //a2.y *= -1;
-                    //a2.z *= -1;
+                    a2.y *= -1;
+                    a2.z *= -1;
                     for (let i = 0; i < patchResolution; i++) {
                         let diff = a2.clone().multiplyScalar(i == 0 ? patchAlignWidth : patchWidth);
                         diff.applyAxisAngle(a1, i * 2 * Math.PI / patchResolution);

--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -1013,14 +1013,17 @@ function addSystemToScene(system) {
             return mesh;
         });
         // Picking
-        s.patchyGeometries.forEach((g, i) => {
+        s.pickingMeshes = s.patchyGeometries.map((g, i) => {
             const pickingGeometry = g.clone();
             pickingGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(s.labels[i], 3));
             pickingGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(s.offsets[i], 3));
             pickingGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(s.visibilities[i], 3));
-            const dummyBackbone = new THREE.Mesh(pickingGeometry, pickingMaterial);
-            dummyBackbone.frustumCulled = false;
-            pickingScene.add(dummyBackbone);
+            const pickingMesh = new THREE.Mesh(pickingGeometry, pickingMaterial);
+            pickingMesh.frustumCulled = false;
+            return pickingMesh;
+        });
+        s.pickingMeshes.forEach(m => {
+            pickingScene.add(m);
         });
     }
     else {

--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -951,6 +951,7 @@ function addSystemToScene(system) {
     // however, if you want to change once stuff is already drawn, you need to add "<attribute>.needsUpdate" before the render() call.
     // This will force the gpu to check the vectors again when redrawing.
     if (system.isPatchySystem()) {
+        // Patchy particle geometries
         let s = system;
         if (s.species !== undefined) {
             const patchResolution = 4;
@@ -960,6 +961,7 @@ function addSystemToScene(system) {
                 let g = new THREE.InstancedBufferGeometry();
                 const points = [new THREE.Vector3()];
                 s.species[i].patches.forEach(patch => {
+                    // Need to invert y and z axis for mysterious reasons
                     const pos = patch.position.clone();
                     pos.y *= -1;
                     pos.z *= -1;
@@ -1005,6 +1007,7 @@ function addSystemToScene(system) {
         });
     }
     else {
+        // Classic nucleic acid geometries
         // Add the geometries to the systems
         system.backboneGeometry = instancedBackbone.clone();
         system.nucleosideGeometry = instancedNucleoside.clone();

--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -497,13 +497,27 @@ function readFiles(topFile, datFile, idxFile, jsonFile, trapFile, parFile, pdbFi
         //setupComplete fires when indexing arrays are finished being set up
         //prevents async issues with par and overlay files
         document.addEventListener('setupComplete', readAuxiliaryFiles);
-        //make system to store the dropped files in
-        const system = new System(sysCount, elements.getNextId());
-        systems.push(system); //add system to Systems[]
-        //TODO: is this really neaded?
-        system.setDatFile(datFile); //store datFile in current System object
-        if (!idxFile) {
-            if (typeof particleFile === "undefined") {
+        if (typeof particleFile !== "undefined") {
+            //make system to store the dropped files in
+            const system = new PatchySystem(sysCount);
+            systems.push(system); //add system to Systems[]
+            //we handle patchy files
+            const patchyTopologyReader = new PatchyTopReader(topFile, system, elements, () => {
+                //fire dat file read from inside top file reader to make sure they don't desync (large protein files will cause a desync)
+                trajReader = new TrajectoryReader(datFile, patchyTopologyReader, system, elements);
+                trajReader.indexTrajectory();
+                //set up patchy instancing data arrays
+                system.initPatchyInstances();
+            });
+            patchyTopologyReader.read();
+        }
+        else {
+            //make system to store the dropped files in
+            const system = new System(sysCount, elements.getNextId());
+            systems.push(system); //add system to Systems[]
+            //TODO: is this really neaded?
+            system.setDatFile(datFile); //store datFile in current System object
+            if (!idxFile) {
                 //read topology file, the configuration file is read once the topology is loaded to avoid async errors
                 const topReader = new TopReader(topFile, system, elements, () => {
                     //fire dat file read from inside top file reader to make sure they don't desync (large protein files will cause a desync)
@@ -515,33 +529,22 @@ function readFiles(topFile, datFile, idxFile, jsonFile, trapFile, parFile, pdbFi
                 topReader.read();
             }
             else {
-                //we handle patchy files
-                const patchyTopologyReader = new PatchyTopReader(topFile, system, elements, () => {
-                    //fire dat file read from inside top file reader to make sure they don't desync (large protein files will cause a desync)
-                    trajReader = new TrajectoryReader(datFile, patchyTopologyReader, system, elements);
-                    trajReader.indexTrajectory();
-                    //set up instancing data arrays
-                    system.initInstances(system.systemLength());
-                });
-                patchyTopologyReader.read();
+                console.log("index provided");
+                const idxReader = new FileReader(); //read .json
+                idxReader.onload = () => {
+                    let file = idxReader.result;
+                    let indexes = JSON.parse(file);
+                    const topReader = new TopReader(topFile, system, elements, () => {
+                        //fire dat file read from inside top file reader to make sure they don't desync (large protein files will cause a desync)
+                        trajReader = new TrajectoryReader(datFile, topReader, system, elements, indexes);
+                        trajReader.nextConfig();
+                        //set up instancing data arrays
+                        system.initInstances(system.systemLength());
+                    });
+                    topReader.read();
+                };
+                idxReader.readAsText(idxFile);
             }
-        }
-        else {
-            console.log("index provided");
-            const idxReader = new FileReader(); //read .json
-            idxReader.onload = () => {
-                let file = idxReader.result;
-                let indexes = JSON.parse(file);
-                const topReader = new TopReader(topFile, system, elements, () => {
-                    //fire dat file read from inside top file reader to make sure they don't desync (large protein files will cause a desync)
-                    trajReader = new TrajectoryReader(datFile, topReader, system, elements, indexes);
-                    trajReader.nextConfig();
-                    //set up instancing data arrays
-                    system.initInstances(system.systemLength());
-                });
-                topReader.read();
-            };
-            idxReader.readAsText(idxFile);
         }
     }
     else if (pdbFile) {
@@ -942,53 +945,78 @@ function addSystemToScene(system) {
     // If you make any modifications to the drawing matricies here, they will take effect before anything draws
     // however, if you want to change once stuff is already drawn, you need to add "<attribute>.needsUpdate" before the render() call.
     // This will force the gpu to check the vectors again when redrawing.
-    // Add the geometries to the systems
-    system.backboneGeometry = instancedBackbone.clone();
-    system.nucleosideGeometry = instancedNucleoside.clone();
-    system.connectorGeometry = instancedConnector.clone();
-    system.spGeometry = instancedBBconnector.clone();
-    system.pickingGeometry = instancedBackbone.clone();
-    // Feed data arrays to the geometries
-    system.backboneGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.bbOffsets, 3));
-    system.backboneGeometry.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(system.bbRotation, 4));
-    system.backboneGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.bbColors, 3));
-    system.backboneGeometry.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(system.scales, 3));
-    system.backboneGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
-    system.nucleosideGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.nsOffsets, 3));
-    system.nucleosideGeometry.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(system.nsRotation, 4));
-    system.nucleosideGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.nsColors, 3));
-    system.nucleosideGeometry.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(system.nsScales, 3));
-    system.nucleosideGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
-    system.connectorGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.conOffsets, 3));
-    system.connectorGeometry.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(system.conRotation, 4));
-    system.connectorGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.bbColors, 3));
-    system.connectorGeometry.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(system.conScales, 3));
-    system.connectorGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
-    system.spGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.bbconOffsets, 3));
-    system.spGeometry.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(system.bbconRotation, 4));
-    system.spGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.bbColors, 3));
-    system.spGeometry.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(system.bbconScales, 3));
-    system.spGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
-    system.pickingGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.bbLabels, 3));
-    system.pickingGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.bbOffsets, 3));
-    system.pickingGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
-    // Those were geometries, the mesh is actually what gets drawn
-    system.backbone = new THREE.Mesh(system.backboneGeometry, instanceMaterial);
-    system.backbone.frustumCulled = false; //you have to turn off culling because instanced materials all exist at (0, 0, 0)
-    system.nucleoside = new THREE.Mesh(system.nucleosideGeometry, instanceMaterial);
-    system.nucleoside.frustumCulled = false;
-    system.connector = new THREE.Mesh(system.connectorGeometry, instanceMaterial);
-    system.connector.frustumCulled = false;
-    system.bbconnector = new THREE.Mesh(system.spGeometry, instanceMaterial);
-    system.bbconnector.frustumCulled = false;
-    system.dummyBackbone = new THREE.Mesh(system.pickingGeometry, pickingMaterial);
-    system.dummyBackbone.frustumCulled = false;
-    // Add everything to the scene (if they are toggled)
-    view.setPropertyInScene('backbone', system);
-    view.setPropertyInScene('nucleoside', system);
-    view.setPropertyInScene('connector', system);
-    view.setPropertyInScene('bbconnector', system);
-    pickingScene.add(system.dummyBackbone);
+    if (system.isPatchySystem()) {
+        let s = system;
+        s.patchyGeometries = s.offsets.map(p => {
+            let g = new THREE.InstancedBufferGeometry();
+            g.copy(new THREE.BoxBufferGeometry(.4, .4, .4));
+            return g;
+        });
+        s.patchyGeometries.forEach((g, i) => {
+            g.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(s.offsets[i], 3));
+            g.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(s.rotations[i], 4));
+            g.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(s.scalings[i], 3));
+            g.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(s.colors[i], 3));
+            g.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(s.visibilities[i], 3));
+        });
+        // Those were geometries, the mesh is actually what gets drawn
+        s.patchyMeshes = s.patchyGeometries.map(g => {
+            const mesh = new THREE.Mesh(g, instanceMaterial);
+            //you have to turn off culling because instanced materials all exist at (0, 0, 0)
+            mesh.frustumCulled = false;
+            scene.add(mesh);
+            return mesh;
+        });
+    }
+    else {
+        // Add the geometries to the systems
+        system.backboneGeometry = instancedBackbone.clone();
+        system.nucleosideGeometry = instancedNucleoside.clone();
+        system.connectorGeometry = instancedConnector.clone();
+        system.spGeometry = instancedBBconnector.clone();
+        system.pickingGeometry = instancedBackbone.clone();
+        // Feed data arrays to the geometries
+        system.backboneGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.bbOffsets, 3));
+        system.backboneGeometry.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(system.bbRotation, 4));
+        system.backboneGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.bbColors, 3));
+        system.backboneGeometry.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(system.scales, 3));
+        system.backboneGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
+        system.nucleosideGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.nsOffsets, 3));
+        system.nucleosideGeometry.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(system.nsRotation, 4));
+        system.nucleosideGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.nsColors, 3));
+        system.nucleosideGeometry.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(system.nsScales, 3));
+        system.nucleosideGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
+        system.connectorGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.conOffsets, 3));
+        system.connectorGeometry.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(system.conRotation, 4));
+        system.connectorGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.bbColors, 3));
+        system.connectorGeometry.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(system.conScales, 3));
+        system.connectorGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
+        system.spGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.bbconOffsets, 3));
+        system.spGeometry.addAttribute('instanceRotation', new THREE.InstancedBufferAttribute(system.bbconRotation, 4));
+        system.spGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.bbColors, 3));
+        system.spGeometry.addAttribute('instanceScale', new THREE.InstancedBufferAttribute(system.bbconScales, 3));
+        system.spGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
+        system.pickingGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(system.bbLabels, 3));
+        system.pickingGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(system.bbOffsets, 3));
+        system.pickingGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(system.visibility, 3));
+        // Those were geometries, the mesh is actually what gets drawn
+        system.backbone = new THREE.Mesh(system.backboneGeometry, instanceMaterial);
+        system.backbone.frustumCulled = false; //you have to turn off culling because instanced materials all exist at (0, 0, 0)
+        system.nucleoside = new THREE.Mesh(system.nucleosideGeometry, instanceMaterial);
+        system.nucleoside.frustumCulled = false;
+        system.connector = new THREE.Mesh(system.connectorGeometry, instanceMaterial);
+        system.connector.frustumCulled = false;
+        system.bbconnector = new THREE.Mesh(system.spGeometry, instanceMaterial);
+        system.bbconnector.frustumCulled = false;
+        system.dummyBackbone = new THREE.Mesh(system.pickingGeometry, pickingMaterial);
+        system.dummyBackbone.frustumCulled = false;
+        // Add everything to the scene (if they are toggled)
+        view.setPropertyInScene('backbone', system);
+        view.setPropertyInScene('nucleoside', system);
+        view.setPropertyInScene('connector', system);
+        view.setPropertyInScene('bbconnector', system);
+        pickingScene.add(system.dummyBackbone);
+    }
     // Let the other file readers know that it's safe to reference system properties
     document.dispatchEvent(new Event('setupComplete'));
     // Reset the cursor from the loading spinny and reset canvas focus

--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -993,7 +993,7 @@ function addSystemToScene(system) {
         else {
             s.patchyGeometries = s.offsets.map(_ => {
                 let g = new THREE.InstancedBufferGeometry();
-                g.copy(new THREE.SphereBufferGeometry(.3, 10, 10));
+                g.copy(new THREE.SphereBufferGeometry(.5, 10, 10));
                 return g;
             });
         }
@@ -1011,6 +1011,16 @@ function addSystemToScene(system) {
             mesh.frustumCulled = false;
             scene.add(mesh);
             return mesh;
+        });
+        // Picking
+        s.patchyGeometries.forEach((g, i) => {
+            const pickingGeometry = g.clone();
+            pickingGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(s.labels[i], 3));
+            pickingGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(s.offsets[i], 3));
+            pickingGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(s.visibilities[i], 3));
+            const dummyBackbone = new THREE.Mesh(pickingGeometry, pickingMaterial);
+            dummyBackbone.frustumCulled = false;
+            pickingScene.add(dummyBackbone);
         });
     }
     else {

--- a/dist/file_handling/io.js
+++ b/dist/file_handling/io.js
@@ -350,7 +350,7 @@ class TrajectoryReader {
                 l = lines[i].split(" ");
                 currentNucleotide.calcPositionsFromConfLine(l, true);
                 //when a strand is finished, add it to the system
-                if (!currentNucleotide.n5 || currentNucleotide.n5 == currentStrand.end3) { //if last nucleotide in straight strand
+                if (currentStrand !== undefined && (!currentNucleotide.n5 || currentNucleotide.n5 == currentStrand.end3)) { //if last nucleotide in straight strand
                     if (currentNucleotide.n5 == currentStrand.end3) {
                         currentStrand.end5 = currentNucleotide;
                     }

--- a/dist/file_handling/io.js
+++ b/dist/file_handling/io.js
@@ -377,15 +377,7 @@ class TrajectoryReader {
                 l = lines[lineNum].split(" ");
                 currentNucleotide.calcPositionsFromConfLine(l);
             }
-            system.backbone.geometry["attributes"].instanceOffset.needsUpdate = true;
-            system.nucleoside.geometry["attributes"].instanceOffset.needsUpdate = true;
-            system.nucleoside.geometry["attributes"].instanceRotation.needsUpdate = true;
-            system.connector.geometry["attributes"].instanceOffset.needsUpdate = true;
-            system.connector.geometry["attributes"].instanceRotation.needsUpdate = true;
-            system.bbconnector.geometry["attributes"].instanceOffset.needsUpdate = true;
-            system.bbconnector.geometry["attributes"].instanceRotation.needsUpdate = true;
-            system.bbconnector.geometry["attributes"].instanceScale.needsUpdate = true;
-            system.dummyBackbone.geometry["attributes"].instanceOffset.needsUpdate = true;
+            system.callUpdates(['instanceOffset', 'instanceRotation']);
         }
         centerAndPBC(system.getMonomers(), newBox);
         if (forceHandler)

--- a/dist/file_handling/order_parameter_selector.js
+++ b/dist/file_handling/order_parameter_selector.js
@@ -54,9 +54,7 @@ let loadHyperSelector = () => {
                 duration: 0 // general animation time
             },
             hover: {
-                animationDuration: 0, // duration of animations when hovering an item
-                // mode:"dataset", // it is possible to remove the line view from the plot 
-                // intersect:true  // on hover, but i find it to distracting 
+                animationDuration: 0,
             },
             responsiveAnimationDuration: 0,
             scales: {

--- a/dist/file_handling/pdb_worker.js
+++ b/dist/file_handling/pdb_worker.js
@@ -23,7 +23,7 @@ var backboneColors = [
     new THREE.Color(0xfdd291),
     new THREE.Color(0xffb322),
     new THREE.Color(0x437092),
-    new THREE.Color(0x6ea4cc), //light blue
+    new THREE.Color(0x6ea4cc),
 ];
 var nucleosideColors = [
     new THREE.Color(0x4747B8),
@@ -63,7 +63,7 @@ var nucleosideColors = [
     //Y
     new THREE.Color(0x8C704C),
     //W
-    new THREE.Color(0x4F4600), //Olive Brown
+    new THREE.Color(0x4F4600),
 ];
 function prep_pdb(pdblines) {
     //Checks for repeated chains, Biological Assemblies etc.

--- a/dist/file_handling/ppio.js
+++ b/dist/file_handling/ppio.js
@@ -16,7 +16,7 @@ class PatchyTopReader extends FileReader {
                 if (!this.LORO) {
                     lines[0].split(" ").forEach((t, i) => {
                         if (t) {
-                            let sphere = new PatchySphere(nucCount + i, this.system);
+                            let sphere = new PatchyParticle(nucCount + i, this.system);
                             this.system.particles.push(sphere);
                             sphere.id = i;
                             this.elems.set(nucCount + i, sphere);
@@ -39,7 +39,7 @@ class PatchyTopReader extends FileReader {
                         let info = line.split(" ");
                         const pcount = parseInt(info[0]);
                         for (let i = pcount * t; i < pcount * (t + 1); i++) {
-                            let sphere = new PatchySphere(nucCount + i, this.system);
+                            let sphere = new PatchyParticle(nucCount + i, this.system);
                             this.system.particles.push(sphere);
                             sphere.sid = this.sidCounter++;
                             sphere.id = nucCount + i;

--- a/dist/file_handling/ppio.js
+++ b/dist/file_handling/ppio.js
@@ -12,46 +12,52 @@ class PatchyTopReader extends FileReader {
                 let lines = file.split(/[\n]+/g);
                 this.configurationLength = parseInt(lines[0].split(" ")[0]);
                 lines = lines.slice(1); // discard the header as we have the info now
+                let speciesCounts = [];
                 if (!this.LORO) {
-                    let currentStrand = this.system.addNewPatchySphereStrand();
                     lines[0].split(" ").forEach((t, i) => {
                         if (t) {
-                            let sphere = currentStrand.createBasicElement(nucCount + i);
-                            sphere.sid = this.sidCounter++;
+                            let sphere = new PatchySphere(nucCount + i, this.system);
+                            this.system.particles.push(sphere);
                             sphere.id = i;
                             this.elems.set(nucCount + i, sphere);
                             sphere.type = t;
+                            const s = parseInt(t);
+                            if (speciesCounts[s] == undefined) {
+                                speciesCounts[s] = 1;
+                            }
+                            else {
+                                speciesCounts[s]++;
+                            }
+                            sphere.sid = speciesCounts[s] - 1;
                             sphere.clusterId = clusterCounter;
                         }
                     });
                 }
                 else {
-                    let currentStrand = this.system.addNewPatchySphereStrand();
                     lines.forEach((line, t) => {
                         console.log(line);
                         let info = line.split(" ");
                         const pcount = parseInt(info[0]);
                         for (let i = pcount * t; i < pcount * (t + 1); i++) {
-                            let sphere = currentStrand.createBasicElement(nucCount + i);
+                            let sphere = new PatchySphere(nucCount + i, this.system);
+                            this.system.particles.push(sphere);
                             sphere.sid = this.sidCounter++;
                             sphere.id = nucCount + i;
+                            sphere.sid = i;
                             this.elems.set(nucCount + i, sphere);
                             sphere.type = t.toString();
+                            // Set the id per species
+                            if (speciesCounts[t] == undefined) {
+                                speciesCounts[t] = 1;
+                            }
+                            else {
+                                speciesCounts[t]++;
+                            }
+                            sphere.sid = speciesCounts[t] - 1;
                             sphere.clusterId = clusterCounter;
                         }
                     });
                 }
-                let particle = this.elems.get(nucCount);
-                particle.n5 = this.elems.get(nucCount + 1);
-                for (let i = 1; i < this.configurationLength - 1; i++) {
-                    let particle = this.elems.get(nucCount + i);
-                    particle.n3 = this.elems.get(nucCount + i - 1);
-                    particle.n5 = this.elems.get(nucCount + i + 1);
-                }
-                particle = this.elems.get(nucCount + this.configurationLength - 1);
-                particle.n3 = this.elems.get(nucCount + this.configurationLength - 2);
-                // Create new cluster for loaded structure:
-                let cluster = ++clusterCounter;
                 nucCount = this.elems.getNextId();
                 // usually the place where the DatReader gets fired
                 this.callback();

--- a/dist/model/basicElement.js
+++ b/dist/model/basicElement.js
@@ -147,6 +147,9 @@ class BasicElement {
     isGS() {
         return false;
     }
+    isPatchyParticle() {
+        return false;
+    }
     toJSON() {
         // Specify required attributes
         let json = {

--- a/dist/model/genericSphere.js
+++ b/dist/model/genericSphere.js
@@ -262,7 +262,6 @@ class PatchySphere extends GenericSphere {
         const defaultA1 = new THREE.Vector3(1, 0, 0);
         const defaultA3 = new THREE.Vector3(0, 0, 1);
         const q = rotateVectorsSimultaneously(defaultA1, defaultA3, a1.clone(), a3.clone());
-        //const q = new THREE.Quaternion();
         console.assert(defaultA1.clone().applyQuaternion(q).distanceTo(a1) < 1e-5, "a1 wrong");
         console.assert(defaultA3.clone().applyQuaternion(q).distanceTo(a3) < 1e-5, "a3 wrong");
         // For some reason, we have to rotate the orientations

--- a/dist/model/genericSphere.js
+++ b/dist/model/genericSphere.js
@@ -211,7 +211,7 @@ class GenericSphere extends BasicElement {
         return json;
     }
 }
-class PatchySphere extends GenericSphere {
+class PatchyParticle extends GenericSphere {
     constructor(id, system) {
         super(id, undefined);
         this.system = system;
@@ -256,8 +256,6 @@ class PatchySphere extends GenericSphere {
     ;
     calcPositions(p, a1, a3, _colorUpdate) {
         let sid = this.sid;
-        let idColor = new THREE.Color();
-        idColor.setHex(this.id + 1); //has to be +1 or you can't grab nucleotide 0
         let scale = 1;
         const defaultA1 = new THREE.Vector3(1, 0, 0);
         const defaultA3 = new THREE.Vector3(0, 0, 1);
@@ -274,6 +272,53 @@ class PatchySphere extends GenericSphere {
         this.system.fillPatchyVec(species, 'scalings', 3, sid, [scale, scale, scale]);
         let color = this.elemToColor(this.type);
         this.system.fillPatchyVec(species, 'colors', 3, sid, [color.r, color.g, color.b]);
+        let idColor = new THREE.Color();
+        idColor.setHex(this.id + 1); //has to be +1 or you can't grab nucleotide 0
+        this.system.fillPatchyVec(species, 'labels', 3, sid, [idColor.r, idColor.g, idColor.b]);
+    }
+    updateColor() {
+        let color;
+        switch (view.coloringMode.get()) {
+            case "System":
+                color = backboneColors[this.getSystem().id % backboneColors.length];
+                break;
+            case "Cluster":
+                if (!this.clusterId || this.clusterId < 0) {
+                    color = new THREE.Color(0xE60A0A);
+                }
+                else {
+                    color = backboneColors[this.clusterId % backboneColors.length];
+                }
+                break;
+            case "Overlay":
+                color = this.system.lutCols[this.sid];
+                break;
+            case "Custom":
+                if (!this.color) {
+                    // Use overlay color if overlay is loaded, otherwise color gray
+                    if (lut) {
+                        color = this.system.lutCols[this.sid];
+                    }
+                    else {
+                        color = GREY;
+                    }
+                }
+                else {
+                    color = this.color;
+                }
+                break;
+            default:
+                color = this.elemToColor(this.type);
+                break;
+        }
+        if (selectedBases.has(this)) {
+            color = color.clone().lerp(selectionColor, 0.6).multiplyScalar(2);
+        }
+        let species = parseInt(this.type);
+        this.system.fillPatchyVec(species, 'colors', 3, this.sid, [color.r, color.g, color.b]);
+    }
+    isPatchyParticle() {
+        return true;
     }
 }
 //https://stackoverflow.com/a/55248720

--- a/dist/model/genericSphere.js
+++ b/dist/model/genericSphere.js
@@ -258,12 +258,6 @@ class PatchySphere extends GenericSphere {
         let sid = this.sid;
         let idColor = new THREE.Color();
         idColor.setHex(this.id + 1); //has to be +1 or you can't grab nucleotide 0
-        //p.y *= -1;
-        //p.z *= -1;
-        //a1.y *= -1;
-        //a1.z *= -1;
-        //a3.y *= -1;
-        //a3.z *= -1;
         let scale = 1;
         const defaultA1 = new THREE.Vector3(1, 0, 0);
         const defaultA3 = new THREE.Vector3(0, 0, 1);

--- a/dist/model/genericSphere.js
+++ b/dist/model/genericSphere.js
@@ -268,8 +268,12 @@ class PatchySphere extends GenericSphere {
         const defaultA1 = new THREE.Vector3(1, 0, 0);
         const defaultA3 = new THREE.Vector3(0, 0, 1);
         const q = rotateVectorsSimultaneously(defaultA1, defaultA3, a1.clone(), a3.clone());
+        //const q = new THREE.Quaternion();
         console.assert(defaultA1.clone().applyQuaternion(q).distanceTo(a1) < 1e-5, "a1 wrong");
         console.assert(defaultA3.clone().applyQuaternion(q).distanceTo(a3) < 1e-5, "a3 wrong");
+        // For some reason, we have to rotate the orientations
+        // around an axis with inverted y-value...
+        q.y *= -1;
         let species = parseInt(this.type);
         this.system.fillPatchyVec(species, 'offsets', 3, sid, p.toArray());
         this.system.fillPatchyVec(species, 'rotations', 4, sid, [q.w, q.z, q.y, q.x]);
@@ -288,8 +292,8 @@ function rotateVectorsSimultaneously(u0, v0, u2, v2) {
     v2.normalize();
     const q2 = new THREE.Quaternion().setFromUnitVectors(u0, u2);
     const v1 = v2.clone().applyQuaternion(q2.clone().conjugate());
-    const v0_proj = v0.projectOnPlane(u0);
-    const v1_proj = v1.projectOnPlane(u0);
+    const v0_proj = v0.clone().projectOnPlane(u0);
+    const v1_proj = v1.clone().projectOnPlane(u0);
     let angleInPlane = v0_proj.angleTo(v1_proj);
     if (v1_proj.dot(new THREE.Vector3().crossVectors(u0, v0)) < 0) {
         angleInPlane *= -1;

--- a/dist/model/genericSphere.js
+++ b/dist/model/genericSphere.js
@@ -12,7 +12,7 @@ class GenericSphere extends BasicElement {
     elemToColor(elem) {
         return GREY;
     }
-    calcPositionsFromConfLine(l, flag) {
+    calcPositionsFromConfLine(l, colorUpdate) {
         //extract position
         const p = new THREE.Vector3(parseFloat(l[0]), parseFloat(l[1]), parseFloat(l[2]));
         this.calcPositions(p);
@@ -212,19 +212,49 @@ class GenericSphere extends BasicElement {
     }
 }
 class PatchySphere extends GenericSphere {
-    constructor(id, strand) {
-        super(id, strand);
+    constructor(id, system) {
+        super(id, undefined);
+        this.system = system;
         this.mass = 10.0;
         this.type = 'ps';
     }
     elemToColor(elem) {
         return colorFromInt(parseInt(elem));
     }
-    calcPositions(p) {
-        let sys = this.getSystem();
-        if (this.dummySys !== null) {
-            sys = this.dummySys;
-        }
+    getSystem() {
+        return this.system;
+    }
+    getPos() {
+        return this.getInstanceParameter3('offsets');
+    }
+    getInstanceParameter3(name) {
+        const a = this.system[name][parseInt(this.type)];
+        return new THREE.Vector3(a[this.sid * 3], a[this.sid * 3 + 1], a[this.sid * 3 + 2]);
+    }
+    //retrieve this element's values in a 4-parameter instance array
+    //only rotations
+    getInstanceParameter4(name) {
+        const a = this.system[name][parseInt(this.type)];
+        return new THREE.Vector4(a[this.sid * 4], a[this.sid * 4 + 1], a[this.sid * 4 + 2], a[this.sid * 4 + 3]);
+    }
+    translatePosition(amount) {
+        const sys = this.system;
+        const id = (this.sid) * 3;
+        const s = parseInt(this.type);
+        sys.offsets[s][id] += amount.x;
+        sys.offsets[s][id + 1] += amount.y;
+        sys.offsets[s][id + 2] += amount.z;
+    }
+    calcPositionsFromConfLine(l, colorUpdate) {
+        //extract position
+        let p = new THREE.Vector3(parseFloat(l[0]), parseFloat(l[1]), parseFloat(l[2]));
+        // extract axis vector a1 (backbone vector) and a3 (stacking vector) 
+        let a1 = new THREE.Vector3(parseFloat(l[3]), parseFloat(l[4]), parseFloat(l[5]));
+        let a3 = new THREE.Vector3(parseFloat(l[6]), parseFloat(l[7]), parseFloat(l[8]));
+        this.calcPositions(p, a1, a3, colorUpdate);
+    }
+    ;
+    calcPositions(p, a1, a3, colorUpdate) {
         let sid = this.sid;
         let idColor = new THREE.Color();
         idColor.setHex(this.id + 1); //has to be +1 or you can't grab nucleotide 0
@@ -236,18 +266,26 @@ class PatchySphere extends GenericSphere {
         else {
             scale = 1;
         }
-        sys.fillVec('cmOffsets', 3, sid, p.toArray());
-        sys.fillVec('bbOffsets', 3, sid, p.toArray());
-        sys.fillVec('bbRotation', 4, sid, [0, 0, 0, 0]);
-        sys.fillVec('nsOffsets', 3, sid, p.toArray());
-        sys.fillVec('nsRotation', 4, sid, [0, 0, 0, 0]);
-        sys.fillVec('scales', 3, sid, [0, 0, 0]);
-        sys.fillVec('nsScales', 3, sid, [scale, scale, scale]);
-        sys.fillVec('conScales', 3, sid, [0, 0, 0]);
-        sys.fillVec('bbconScales', 3, sid, [0, 0, 0]);
-        sys.fillVec('visibility', 3, sid, [1, 1, 1]);
+        let q = rotateVectorsSimultaneously(new THREE.Vector3(0, 0, 1), new THREE.Vector3(1, 0, 0), a3, a1);
+        let species = parseInt(this.type);
+        this.system.fillPatchyVec(species, 'offsets', 3, sid, p.toArray());
+        this.system.fillPatchyVec(species, 'rotations', 4, sid, [q.w, q.z, q.y, q.x]);
+        this.system.fillPatchyVec(species, 'visibilities', 3, sid, [1, 1, 1]);
+        this.system.fillPatchyVec(species, 'scalings', 3, sid, [scale, scale, scale]);
         let color = this.elemToColor(this.type);
-        sys.fillVec('nsColors', 3, sid, [color.r, color.g, color.b]);
-        sys.fillVec('bbLabels', 3, sid, [idColor.r, idColor.g, idColor.b]);
+        this.system.fillPatchyVec(species, 'colors', 3, sid, [color.r, color.g, color.b]);
     }
+}
+function rotateVectorsSimultaneously(u0, v0, u2, v2) {
+    const q2 = new THREE.Quaternion().setFromUnitVectors(u0, u2);
+    const v1 = v2.clone().applyQuaternion(q2.clone().conjugate());
+    const v0_proj = v0.projectOnPlane(u0);
+    const v1_proj = v1.projectOnPlane(u0);
+    let angleInPlane = v0_proj.angleTo(v1_proj);
+    if (v1_proj.dot(new THREE.Vector3().crossVectors(u0, v0)) < 0) {
+        angleInPlane *= -1;
+    }
+    const q1 = new THREE.Quaternion().setFromAxisAngle(u0, angleInPlane);
+    const q = new THREE.Quaternion().multiplyQuaternions(q2, q1);
+    return q;
 }

--- a/dist/model/strand.js
+++ b/dist/model/strand.js
@@ -376,9 +376,3 @@ class Generic extends Strand {
         this.forEach(e => e.deselect());
     }
 }
-class PatchyStrand extends Generic {
-    createBasicElement(id) {
-        return new PatchySphere(id, this);
-    }
-    ;
-}

--- a/dist/model/system.js
+++ b/dist/model/system.js
@@ -147,13 +147,6 @@ class System {
         this.strands.push(strand);
         return strand;
     }
-    addNewPatchySphereStrand() {
-        let id = this.getNextGenericSphereStrandID();
-        let strand = new PatchyStrand(id, this);
-        strand.system = this;
-        this.strands.push(strand);
-        return strand;
-    }
     addStrand(strand) {
         if (!this.strands.includes(strand)) {
             this.strands.push(strand);
@@ -225,6 +218,9 @@ class System {
         }
     }
     ;
+    isPatchySystem() {
+        return false;
+    }
     toJSON() {
         // Specify required attributes
         let json = {
@@ -240,3 +236,51 @@ class System {
     ;
 }
 ;
+class PatchySystem extends System {
+    constructor(id) {
+        super(id, 0);
+        this.id = id;
+        this.particles = [];
+    }
+    ;
+    isPatchySystem() {
+        return true;
+    }
+    getMonomers() {
+        return this.particles;
+    }
+    systemLength() {
+        return this.particles.length;
+    }
+    ;
+    initPatchyInstances() {
+        const types = this.particles.map(p => parseInt(p.type));
+        const instanceCounts = [];
+        types.forEach(s => {
+            if (instanceCounts[s] === undefined) {
+                instanceCounts[s] = 1;
+            }
+            else {
+                instanceCounts[s]++;
+            }
+        });
+        this.offsets = instanceCounts.map(n => new Float32Array(n * 3));
+        this.rotations = instanceCounts.map(n => new Float32Array(n * 4));
+        this.colors = instanceCounts.map(n => new Float32Array(n * 3));
+        this.scalings = instanceCounts.map(n => new Float32Array(n * 3));
+        this.visibilities = instanceCounts.map(n => new Float32Array(n * 3));
+    }
+    callUpdates(names) {
+        names.forEach((name) => {
+            this.patchyMeshes.forEach(mesh => {
+                mesh.geometry["attributes"][name].needsUpdate = true;
+            });
+        });
+    }
+    fillPatchyVec(species, vecName, unitSize, pos, vals) {
+        for (let i = 0; i < unitSize; i++) {
+            this[vecName][species][pos * unitSize + i] = vals[i];
+        }
+    }
+    ;
+}

--- a/dist/model/system.js
+++ b/dist/model/system.js
@@ -339,6 +339,7 @@ class PatchySystem extends System {
         this.colors = instanceCounts.map(n => new Float32Array(n * 3));
         this.scalings = instanceCounts.map(n => new Float32Array(n * 3));
         this.visibilities = instanceCounts.map(n => new Float32Array(n * 3));
+        this.labels = instanceCounts.map(n => new Float32Array(n * 3));
     }
     callUpdates(names) {
         names.forEach((name) => {

--- a/dist/model/system.js
+++ b/dist/model/system.js
@@ -346,6 +346,9 @@ class PatchySystem extends System {
             this.patchyMeshes.forEach(mesh => {
                 mesh.geometry["attributes"][name].needsUpdate = true;
             });
+            this.pickingMeshes.forEach(mesh => {
+                mesh.geometry["attributes"][name].needsUpdate = true;
+            });
         });
     }
     fillPatchyVec(species, vecName, unitSize, pos, vals) {

--- a/dist/model/system.js
+++ b/dist/model/system.js
@@ -237,12 +237,82 @@ class System {
 }
 ;
 class PatchySystem extends System {
-    constructor(id) {
+    constructor(id, particleFile, patchFile) {
         super(id, 0);
         this.id = id;
         this.particles = [];
+        if (patchFile) {
+            particleFile.text().then(particlesStr => {
+                patchFile.text().then(patchesStr => {
+                    this.initSpecies(particlesStr, patchesStr);
+                });
+            });
+        }
     }
     ;
+    initSpecies(particlesStr, patchesStr) {
+        // Remove whitespace
+        particlesStr = particlesStr.replaceAll(' ', '');
+        patchesStr = patchesStr.replaceAll(' ', '');
+        const getScalar = (name, s) => {
+            const m = s.match(new RegExp(`${name}=(-?\\d+)`));
+            if (m) {
+                return parseFloat(m[1]);
+            }
+            return false;
+        };
+        const getArray = (name, s) => {
+            const m = s.match(new RegExp(`${name}=([\\,\\d\\.\\-\\+]+)`));
+            if (m) {
+                return m[1].split(',').map((v) => parseFloat(v));
+            }
+            return false;
+        };
+        let particles = [];
+        let currentParticle;
+        for (const line of particlesStr.split('\n')) {
+            const particleID = line.match(/particle_(\d+)/);
+            if (particleID) {
+                if (currentParticle) {
+                    particles.push(currentParticle);
+                }
+                currentParticle = { 'id': parseInt(particleID[1]) };
+            }
+            const type = getScalar('type', line);
+            if (type !== false) {
+                currentParticle['type'] = type;
+            }
+            const patches = getArray('patches', line);
+            if (patches !== false) {
+                currentParticle['patches'] = patches;
+            }
+        }
+        particles.push(currentParticle);
+        let patches = new Map();
+        let currentId;
+        for (const line of patchesStr.split('\n')) {
+            const patchID = line.match(/patch_(\d+)/);
+            if (patchID) {
+                currentId = parseInt(patchID[1]);
+                patches.set(currentId, {});
+            }
+            const color = getScalar('color', line);
+            if (color !== false) {
+                patches.get(currentId)['color'] = color;
+            }
+            for (const k of ['position', 'a1', 'a2']) {
+                const a = getArray(k, line);
+                if (a) {
+                    const v = new THREE.Vector3().fromArray(a);
+                    patches.get(currentId)[k] = v;
+                }
+            }
+        }
+        for (const particle of particles) {
+            particle['patches'] = particle['patches'].map(id => patches.get(id));
+        }
+        this.species = particles;
+    }
     isPatchySystem() {
         return true;
     }

--- a/dist/scene/PBC_switchbox.js
+++ b/dist/scene/PBC_switchbox.js
@@ -19,6 +19,28 @@ function centerAndPBCBtnClick(elems) {
     }
     centerAndPBC(elems);
 }
+function shiftWithinBox(v, elems, targetBox) {
+    if (!elems) {
+        elems = Array.from(elements.values());
+    }
+    if (!targetBox) {
+        targetBox = box;
+    }
+    translateElements(new Set(elems), v);
+    bringInBox(elems, getInboxingMode(), targetBox);
+    // Update instances
+    let affectedSystems = new Set();
+    elems.forEach(e => {
+        if (e.n3)
+            calcsp(e);
+        affectedSystems.add(e.getSystem());
+    });
+    affectedSystems.forEach(s => s.callUpdates(['instanceOffset']));
+    tmpSystems.forEach(s => s.callUpdates(['instanceOffset']));
+    if (forceHandler)
+        forceHandler.redraw();
+    render();
+}
 /**
  * Center elements in the simulation box and then apply periodic boundary conditions to bring them all in the same box instance.
  * @param elems Optional parameter defining which particles to apply the centering and PBC to.  Defaults to all particles.

--- a/index.html
+++ b/index.html
@@ -1085,6 +1085,8 @@
         <script src="./ts/lib/VRButton.js"></script>
         <script src="./ts/controls/TransformControls.js"></script>
         <script src="./ts/controls/TrackballControls.js"></script>
+        <script src="./ts/geometries/ConvexHull.js"></script>
+        <script src="./ts/geometries/ConvexGeometry.js"></script>
         <script src="./dist/scene/scene_setup.js"></script>
         <script src="./dist/scene/instancing.js"></script>
         <script src="./dist/scene/mesh_setup.js"></script>

--- a/index.html
+++ b/index.html
@@ -87,6 +87,12 @@
             <tr><td>Numpad6</td><td>Rotate camera right</td></tr>
             <tr><td>Numpad7</td><td>Move camera to z-axis (Ctrl/⌘ to invert)</td></tr>
             <tr><td>Numpad8</td><td>Rotate camera up</td></tr>
+            <tr><td>x</td><td>Shift along x-axis (with PBC)</td></tr>
+            <tr><td>Shift-x</td><td>Shift along negative x-axis (with PBC)</td></tr>
+            <tr><td>y</td><td>Shift along y-axis (with PBC)</td></tr>
+            <tr><td>Shift-y</td><td>Shift along negative y-axis (with PBC)</td></tr>
+            <tr><td>z</td><td>Shift along z-axis (with PBC)</td></tr>
+            <tr><td>Shift-z</td><td>Shift along negative z-axis (with PBC)</td></tr>
         </table>
     </div>
 

--- a/ts/UI/UI.ts
+++ b/ts/UI/UI.ts
@@ -716,7 +716,11 @@ class View {
     public showHoverInfo(pos: THREE.Vector2, e: BasicElement) {
         let hoverInfo = document.getElementById('hoverInfo');
         let color = e.elemToColor(e.type).getHexString();
-        hoverInfo.innerHTML = `<span style="background:#${color}4f; padding: 5px">${e.type} ${e.getSystem().id}:${e.strand.id}:${e.id}</span>`;
+        if (e.isPatchyParticle()) {
+            hoverInfo.innerHTML = `<span style="background:#${color}4f; padding: 5px">${e.type} ${e.getSystem().id}:${e.id}</span>`;
+        } else {
+            hoverInfo.innerHTML = `<span style="background:#${color}4f; padding: 5px">${e.type} ${e.getSystem().id}:${e.strand.id}:${e.id}</span>`;
+        }
         hoverInfo.style.left = pos.x  + 'px';
         hoverInfo.style.top =  pos.y + 20 + 'px';
         hoverInfo.hidden = false;

--- a/ts/UI/base_selector.ts
+++ b/ts/UI/base_selector.ts
@@ -151,12 +151,14 @@ function updateView(sys: System) {
 			//store global ids for BaseList view
 			listBases.push(base.id);
 
-			//assign each of the selected bases to a strand
-			let strandID = base.strand.id;
-			if(strandID in baseInfoStrands)
-				baseInfoStrands[strandID].push(base);
-			else
-				baseInfoStrands[strandID] = [base];
+			if (!base.isPatchyParticle) {
+				//assign each of the selected bases to a strand
+				let strandID = base.strand.id;
+				if(strandID in baseInfoStrands)
+					baseInfoStrands[strandID].push(base);
+				else
+					baseInfoStrands[strandID] = [base];
+			}
 		}
 	);
 

--- a/ts/UI/keybindings.ts
+++ b/ts/UI/keybindings.ts
@@ -16,7 +16,16 @@ canvas.addEventListener("keydown", event =>{
 
         // Copy, cut, paste and delete. Holding shift pastes with preserved location
         case 'c': if (event.ctrlKey || event.metaKey) {copyWrapper();} break;
-        case 'x': if (event.ctrlKey || event.metaKey) {cutWrapper();} break;
+        case 'x':
+            if (event.ctrlKey || event.metaKey) {
+                cutWrapper();
+            } else {
+                if (event.shiftKey) {
+                    shiftWithinBox(new THREE.Vector3(-1,0,0))
+                } else {
+                    shiftWithinBox(new THREE.Vector3(1,0,0))
+                }
+            } break;
         case 'v': if (event.ctrlKey || event.metaKey) {
             pasteWrapper(!event.shiftKey); // Hold down shift to paste in front of camera
             view.transformMode.set('Translate'); // Show translate gizmo
@@ -29,11 +38,27 @@ canvas.addEventListener("keydown", event =>{
 
         // Undo: ctrl-z, cmd-z
         // Redo: ctrl-shift-z, ctrl-y, cmd-shift-z, cmd-y
-        case 'z': if (event.ctrlKey || event.metaKey) {
+        case 'z':
+            if (event.ctrlKey || event.metaKey) {
                 if (event.shiftKey) {editHistory.redo();}
                 else {editHistory.undo();}
+            } else {
+                if (event.shiftKey) {
+                    shiftWithinBox(new THREE.Vector3(0,0,-1))
+                } else {
+                    shiftWithinBox(new THREE.Vector3(0,0,1))
+                }
             } break;
-        case 'y': if (event.ctrlKey || event.metaKey) {editHistory.redo();} break;
+        case 'y':
+            if (event.ctrlKey || event.metaKey) {
+                editHistory.redo();
+            } else {
+                if (event.shiftKey) {
+                    shiftWithinBox(new THREE.Vector3(0,-1,0))
+                } else {
+                    shiftWithinBox(new THREE.Vector3(0,1,0))
+                }
+            } break;
 
         // Select everything not selected:
         case 'i': if (event.ctrlKey || event.metaKey) {event.preventDefault(); invertSelection()} break;

--- a/ts/api/scene_api.ts
+++ b/ts/api/scene_api.ts
@@ -192,16 +192,36 @@ module api{
      * Show the specified element in the viewport
      * @param element Element to center view at
      */
-    export function findElement(element: BasicElement) {
-        let targetPos = element.getInstanceParameter3('bbOffsets');
+    export function findElement(element: BasicElement, steps=50) {
+        let targetPos: THREE.Vector3;
+        if (element.isNucleotide()) {
+            targetPos = element.getInstanceParameter3('bbOffsets');
+        } else {
+            targetPos = element.getPos()
+        }
 
         // Target trackball controls at element position
-        controls.target = targetPos;
+        //controls.target = targetPos;
 
         // Move in close to the element
-        let targetDist = 3;
+        let targetDist = 10;
         let dist = (camera.position.distanceTo(targetPos));
-        camera.position.lerp(targetPos, 1-(targetDist/dist));
+
+        let endPos = camera.position.clone().sub(targetPos).setLength(targetDist).add(targetPos);
+
+        if (steps > 1) {
+            camera.position.lerp(endPos, 1/steps);
+            controls.target.lerp(targetPos, 1/steps);
+        } else {
+            camera.position.lerp(endPos, 1-(targetDist/dist));
+            controls.target = targetPos;
+        }
+
+        if (steps > 1) {
+            requestAnimationFrame(()=>{
+                api.findElement(element, steps-1);
+            });
+        }
     }
 
     export function selectElements(elems: BasicElement[], keepPrevious?: boolean) {

--- a/ts/api/scene_api.ts
+++ b/ts/api/scene_api.ts
@@ -192,7 +192,7 @@ module api{
      * Show the specified element in the viewport
      * @param element Element to center view at
      */
-    export function findElement(element: BasicElement, steps=50) {
+    export function findElement(element: BasicElement, steps=20) {
         let targetPos: THREE.Vector3;
         if (element.isNucleotide()) {
             targetPos = element.getInstanceParameter3('bbOffsets');

--- a/ts/controls/TransformControls.js
+++ b/ts/controls/TransformControls.js
@@ -155,7 +155,13 @@ THREE.TransformControls = function ( camera, domElement ) {
 		this.visible = true;
 
 		currentPosition = new THREE.Vector3();
-		selectedBases.forEach(e => currentPosition.add(e.getInstanceParameter3("bbOffsets")));
+		selectedBases.forEach(e => {
+			if (e.isNucleotide()) {
+				currentPosition.add(e.getInstanceParameter3("bbOffsets"))
+			} else {
+				currentPosition.add(e.getPos());
+			}
+		});
 		currentPosition.divideScalar(selectedBases.size);
 
 		rotation = new THREE.Vector3()
@@ -276,7 +282,13 @@ THREE.TransformControls = function ( camera, domElement ) {
 
 		// Calculate COM as position
 		position = new THREE.Vector3(); //currentPosition.clone();
-		selectedBases.forEach(e => position.add(e.getInstanceParameter3("bbOffsets")));
+		selectedBases.forEach(e => {
+			if (e.isNucleotide()) {
+				position.add(e.getInstanceParameter3("bbOffsets"))
+			} else {
+				position.add(e.getPos());
+			}
+		});
 		position.divideScalar(selectedBases.size);
 
 		if ( ( pointer.button === 0 || pointer.button === undefined ) && this.axis !== null ) {

--- a/ts/editing/translation.ts
+++ b/ts/editing/translation.ts
@@ -26,56 +26,73 @@ function rotateElementsByQuaternion(elements: Set<BasicElement>, q: THREE.Quater
             sys = e.dummySys;
         }
 
-        //get current positions
-        let cmPos = e.getPos();
-        let bbPos = e.getInstanceParameter3("bbOffsets");
-        let nsPos = e.getInstanceParameter3("nsOffsets");
-        let conPos = e.getInstanceParameter3("conOffsets");
-        let bbconPos = e.getInstanceParameter3("bbconOffsets");
+        if (sys.isPatchySystem()) {
+            let p = e.getPos();
+            p.sub(about);
+            p.applyQuaternion(q);
 
-        //the rotation center needs to be (0,0,0)
-        cmPos.sub(about);
-        bbPos.sub(about);
-        nsPos.sub(about);
-        conPos.sub(about);
-        bbconPos.sub(about);
+            let rotation = glsl2three(e.getInstanceParameter4("rotations"));
+            rotation.multiply(q2);
+            p.add(about);
 
-        cmPos.applyQuaternion(q);
-        bbPos.applyQuaternion(q);
-        nsPos.applyQuaternion(q);
-        conPos.applyQuaternion(q);
-        bbconPos.applyQuaternion(q);
+            (sys as PatchySystem).fillPatchyVec(
+                parseInt(e.type), 'offsets', 3, e.sid, p.toArray()
+            );
+            (sys as PatchySystem).fillPatchyVec(
+                parseInt(e.type),'rotations', 4, e.sid, [rotation.w, rotation.z, rotation.y, rotation.x]
+            );
+        } else {
+            //get current positions
+            let cmPos = e.getPos();
+            let bbPos = e.getInstanceParameter3("bbOffsets");
+            let nsPos = e.getInstanceParameter3("nsOffsets");
+            let conPos = e.getInstanceParameter3("conOffsets");
+            let bbconPos = e.getInstanceParameter3("bbconOffsets");
 
-        //get current rotations and convert to THREE coordinates
-        let nsRotationV = e.getInstanceParameter4("nsRotation");
-        let nsRotation =  glsl2three(nsRotationV);
-        let conRotationV = e.getInstanceParameter4("conRotation");
-        let conRotation = glsl2three(conRotationV);
-        let bbconRotationV = e.getInstanceParameter4("bbconRotation");
-        let bbconRotation = glsl2three(bbconRotationV);
+            //the rotation center needs to be (0,0,0)
+            cmPos.sub(about);
+            bbPos.sub(about);
+            nsPos.sub(about);
+            conPos.sub(about);
+            bbconPos.sub(about);
 
-        //apply individual object rotation
-        nsRotation.multiply(q2);
-        conRotation.multiply(q2);
-        bbconRotation.multiply(q2);
+            cmPos.applyQuaternion(q);
+            bbPos.applyQuaternion(q);
+            nsPos.applyQuaternion(q);
+            conPos.applyQuaternion(q);
+            bbconPos.applyQuaternion(q);
 
-        //move the object back to its original position
-        cmPos.add(about);
-        bbPos.add(about);
-        nsPos.add(about);
-        conPos.add(about);
-        bbconPos.add(about);
+            //get current rotations and convert to THREE coordinates
+            let nsRotationV = e.getInstanceParameter4("nsRotation");
+            let nsRotation =  glsl2three(nsRotationV);
+            let conRotationV = e.getInstanceParameter4("conRotation");
+            let conRotation = glsl2three(conRotationV);
+            let bbconRotationV = e.getInstanceParameter4("bbconRotation");
+            let bbconRotation = glsl2three(bbconRotationV);
 
-        //update the instancing matrices
-        sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
-        sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
-        sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);
-        sys.fillVec('conOffsets', 3, sid, [conPos.x, conPos.y, conPos.z]);
-        sys.fillVec('bbconOffsets', 3, sid, [bbconPos.x, bbconPos.y, bbconPos.z]);
-        
-        sys.fillVec('nsRotation', 4, sid, [nsRotation.w, nsRotation.z, nsRotation.y, nsRotation.x]);
-        sys.fillVec('conRotation', 4, sid, [conRotation.w, conRotation.z, conRotation.y, conRotation.x]);
-        sys.fillVec('bbconRotation', 4, sid, [bbconRotation.w, bbconRotation.z, bbconRotation.y, bbconRotation.x]);
+            //apply individual object rotation
+            nsRotation.multiply(q2);
+            conRotation.multiply(q2);
+            bbconRotation.multiply(q2);
+
+            //move the object back to its original position
+            cmPos.add(about);
+            bbPos.add(about);
+            nsPos.add(about);
+            conPos.add(about);
+            bbconPos.add(about);
+
+            //update the instancing matrices
+            sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
+            sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
+            sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);
+            sys.fillVec('conOffsets', 3, sid, [conPos.x, conPos.y, conPos.z]);
+            sys.fillVec('bbconOffsets', 3, sid, [bbconPos.x, bbconPos.y, bbconPos.z]);
+
+            sys.fillVec('nsRotation', 4, sid, [nsRotation.w, nsRotation.z, nsRotation.y, nsRotation.x]);
+            sys.fillVec('conRotation', 4, sid, [conRotation.w, conRotation.z, conRotation.y, conRotation.x]);
+            sys.fillVec('bbconRotation', 4, sid, [bbconRotation.w, bbconRotation.z, bbconRotation.y, bbconRotation.x]);
+        }
     });
 
     if (updateScene){
@@ -159,6 +176,7 @@ function translateElements(elements: Set<BasicElement>, v: THREE.Vector3) {
 
         if (sys.isPatchySystem()) {
             let p = e.getPos();
+            p.add(v);
             (sys as PatchySystem).fillPatchyVec(
                 parseInt(e.type), 'offsets', 3, e.sid, p.toArray()
             )
@@ -168,13 +186,13 @@ function translateElements(elements: Set<BasicElement>, v: THREE.Vector3) {
             let nsPos = e.getInstanceParameter3("nsOffsets");
             let conPos = e.getInstanceParameter3("conOffsets");
             let bbconPos = e.getInstanceParameter3("bbconOffsets");
-    
+
             cmPos.add(v);
             bbPos.add(v);
             nsPos.add(v);
             conPos.add(v);
             bbconPos.add(v);
-    
+
             sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
             sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
             sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);

--- a/ts/editing/translation.ts
+++ b/ts/editing/translation.ts
@@ -157,23 +157,30 @@ function translateElements(elements: Set<BasicElement>, v: THREE.Vector3) {
             sys = e.dummySys;
         }
 
-        let cmPos = e.getPos();
-        let bbPos = e.getInstanceParameter3("bbOffsets");
-        let nsPos = e.getInstanceParameter3("nsOffsets");
-        let conPos = e.getInstanceParameter3("conOffsets");
-        let bbconPos = e.getInstanceParameter3("bbconOffsets");
-
-        cmPos.add(v);
-        bbPos.add(v);
-        nsPos.add(v);
-        conPos.add(v);
-        bbconPos.add(v);
-
-        sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
-        sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
-        sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);
-        sys.fillVec('conOffsets', 3, sid, [conPos.x, conPos.y, conPos.z]);
-        sys.fillVec('bbconOffsets', 3, sid, [bbconPos.x, bbconPos.y, bbconPos.z]);
+        if (sys.isPatchySystem()) {
+            let p = e.getPos();
+            (sys as PatchySystem).fillPatchyVec(
+                parseInt(e.type), 'offsets', 3, e.sid, p.toArray()
+            )
+        } else {
+            let cmPos = e.getPos();
+            let bbPos = e.getInstanceParameter3("bbOffsets");
+            let nsPos = e.getInstanceParameter3("nsOffsets");
+            let conPos = e.getInstanceParameter3("conOffsets");
+            let bbconPos = e.getInstanceParameter3("bbconOffsets");
+    
+            cmPos.add(v);
+            bbPos.add(v);
+            nsPos.add(v);
+            conPos.add(v);
+            bbconPos.add(v);
+    
+            sys.fillVec('cmOffsets', 3, sid, [cmPos.x, cmPos.y, cmPos.z]);
+            sys.fillVec('bbOffsets', 3, sid, [bbPos.x, bbPos.y, bbPos.z]);
+            sys.fillVec('nsOffsets', 3, sid, [nsPos.x, nsPos.y, nsPos.z]);
+            sys.fillVec('conOffsets', 3, sid, [conPos.x, conPos.y, conPos.z]);
+            sys.fillVec('bbconOffsets', 3, sid, [bbconPos.x, bbconPos.y, bbconPos.z]);
+        }
     });
 
     // Update backbone connections (is there a more clever way to do this than

--- a/ts/file_handling/file_reading.ts
+++ b/ts/file_handling/file_reading.ts
@@ -1041,7 +1041,7 @@ function addSystemToScene(system: System) {
         let s = system as PatchySystem;
         if (s.species !== undefined) {
 
-            const patchResolution = 32;
+            const patchResolution = 4;
             const patchWidth = 0.2;
             const patchAlignWidth = 0.3;
 
@@ -1052,17 +1052,16 @@ function addSystemToScene(system: System) {
 
                 s.species[i].patches.forEach(patch=>{
                     const pos = patch.position.clone();
-                    //pos.x *= -1;
-                    //pos.y *= -1;
-                    //pos.z *= -1;
+                    pos.y *= -1;
+                    pos.z *= -1;
 
                     const a1 = patch.a1.clone();
-                    //a1.y *= -1;
-                    //a1.z *= -1;
+                    a1.y *= -1;
+                    a1.z *= -1;
 
                     const a2 = patch.a2.clone();
-                    //a2.y *= -1;
-                    //a2.z *= -1;
+                    a2.y *= -1;
+                    a2.z *= -1;
                     for (let i=0; i<patchResolution; i++) {
                         let diff = a2.clone().multiplyScalar(i == 0 ? patchAlignWidth : patchWidth);
                         diff.applyAxisAngle(

--- a/ts/file_handling/file_reading.ts
+++ b/ts/file_handling/file_reading.ts
@@ -1042,9 +1042,10 @@ function addSystemToScene(system: System) {
         let s = system as PatchySystem;
         if (s.species !== undefined) {
 
-            const patchResolution = 4;
-            const patchWidth = 0.2;
-            const patchAlignWidth = 0.3;
+            const patchResolution = 4; // Number of points defining each patch
+            const patchWidth = 0.2; // Radius of patch "circle"
+            const patchAlignWidth = 0.3; // Widest radius of patch circle
+                                         // (indicating patch alignment)
 
             s.patchyGeometries = s.offsets.map((_,i)=>{
                 let g = new THREE.InstancedBufferGeometry();
@@ -1064,17 +1065,23 @@ function addSystemToScene(system: System) {
                     const a2 = patch.a2.clone();
                     a2.y *= -1;
                     a2.z *= -1;
-                    for (let i=0; i<patchResolution; i++) {
-                        let diff = a2.clone().multiplyScalar(i == 0 ? patchAlignWidth : patchWidth);
-                        diff.applyAxisAngle(
-                            a1,
-                            i * 2*Math.PI/patchResolution
-                        );
-                        points.push(
-                            pos.clone().add(diff)
-                        );
+
+                    // Too many patches.txt files fail to set a1 and a2 correctly.
+                    if (Math.abs(a1.dot(a2)) > 1e-5) {
+                        console.warn(`The a1 and a2 vectors are incorrectly defined in species ${i}. Using patch position instead`);
+                        points.push(pos.clone());
+                    } else {
+                        for (let i=0; i<patchResolution; i++) {
+                            let diff = a2.clone().multiplyScalar(i == 0 ? patchAlignWidth : patchWidth);
+                            diff.applyAxisAngle(
+                                a1,
+                                i * 2*Math.PI/patchResolution
+                            );
+                            points.push(
+                                pos.clone().add(diff)
+                            );
+                        }
                     }
-                    console.log(`Patch at ${patch.position.toArray()}`);
                 });
                 let particleGeometry = new THREE.ConvexGeometry(points);
 

--- a/ts/file_handling/file_reading.ts
+++ b/ts/file_handling/file_reading.ts
@@ -1038,6 +1038,7 @@ function addSystemToScene(system: System) {
     // This will force the gpu to check the vectors again when redrawing.
 
     if (system.isPatchySystem()) {
+        // Patchy particle geometries
         let s = system as PatchySystem;
         if (s.species !== undefined) {
 
@@ -1051,6 +1052,7 @@ function addSystemToScene(system: System) {
                 const points = [new THREE.Vector3()];
 
                 s.species[i].patches.forEach(patch=>{
+                    // Need to invert y and z axis for mysterious reasons
                     const pos = patch.position.clone();
                     pos.y *= -1;
                     pos.z *= -1;
@@ -1105,6 +1107,8 @@ function addSystemToScene(system: System) {
         });
 
     } else {
+        // Classic nucleic acid geometries
+
         // Add the geometries to the systems
         system.backboneGeometry = instancedBackbone.clone();
         system.nucleosideGeometry = instancedNucleoside.clone();

--- a/ts/file_handling/file_reading.ts
+++ b/ts/file_handling/file_reading.ts
@@ -1114,15 +1114,17 @@ function addSystemToScene(system: System) {
         });
 
         // Picking
-        s.patchyGeometries.forEach((g,i)=>{
+        s.pickingMeshes = s.patchyGeometries.map((g,i)=>{
             const pickingGeometry = g.clone();
             pickingGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(s.labels[i], 3));
             pickingGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(s.offsets[i], 3));
             pickingGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(s.visibilities[i], 3));
-            const dummyBackbone = new THREE.Mesh(pickingGeometry, pickingMaterial);
-            dummyBackbone.frustumCulled = false;
-
-            pickingScene.add(dummyBackbone);
+            const pickingMesh = new THREE.Mesh(pickingGeometry, pickingMaterial);
+            pickingMesh.frustumCulled = false;
+            return pickingMesh;
+        });
+        s.pickingMeshes.forEach(m=>{
+            pickingScene.add(m);
         });
 
     } else {

--- a/ts/file_handling/file_reading.ts
+++ b/ts/file_handling/file_reading.ts
@@ -1091,7 +1091,7 @@ function addSystemToScene(system: System) {
         } else {
             s.patchyGeometries = s.offsets.map(_=>{
                 let g = new THREE.InstancedBufferGeometry();
-                g.copy(new THREE.SphereBufferGeometry(.3,10,10) as unknown as THREE.InstancedBufferGeometry);
+                g.copy(new THREE.SphereBufferGeometry(.5,10,10) as unknown as THREE.InstancedBufferGeometry);
                 return g;
             });
         }
@@ -1111,6 +1111,18 @@ function addSystemToScene(system: System) {
 
             scene.add(mesh);
             return mesh;
+        });
+
+        // Picking
+        s.patchyGeometries.forEach((g,i)=>{
+            const pickingGeometry = g.clone();
+            pickingGeometry.addAttribute('instanceColor', new THREE.InstancedBufferAttribute(s.labels[i], 3));
+            pickingGeometry.addAttribute('instanceOffset', new THREE.InstancedBufferAttribute(s.offsets[i], 3));
+            pickingGeometry.addAttribute('instanceVisibility', new THREE.InstancedBufferAttribute(s.visibilities[i], 3));
+            const dummyBackbone = new THREE.Mesh(pickingGeometry, pickingMaterial);
+            dummyBackbone.frustumCulled = false;
+
+            pickingScene.add(dummyBackbone);
         });
 
     } else {

--- a/ts/file_handling/io.ts
+++ b/ts/file_handling/io.ts
@@ -437,11 +437,11 @@ class TrajectoryReader {
                 };
                 // get the nucleotide associated with the line
                 currentNucleotide = elements.get(i+system.globalStartId);
-            
+
                 // consume a new line from the file
                 l = lines[i].split(" ");
                 currentNucleotide.calcPositionsFromConfLine(l, true);
-            
+
                 //when a strand is finished, add it to the system
                 if (currentStrand !== undefined && (!currentNucleotide.n5 || currentNucleotide.n5 == currentStrand.end3)) { //if last nucleotide in straight strand
                     if (currentNucleotide.n5 == currentStrand.end3) {
@@ -453,7 +453,7 @@ class TrajectoryReader {
                         currentStrand = elements.get(currentNucleotide.id+1).strand;
                     }
                 }
-            
+
             }
             addSystemToScene(system);
             sysCount++;
@@ -470,15 +470,7 @@ class TrajectoryReader {
                 l = lines[lineNum].split(" ");
                 currentNucleotide.calcPositionsFromConfLine(l);
             }
-            system.backbone.geometry["attributes"].instanceOffset.needsUpdate = true;
-            system.nucleoside.geometry["attributes"].instanceOffset.needsUpdate = true;
-            system.nucleoside.geometry["attributes"].instanceRotation.needsUpdate = true;
-            system.connector.geometry["attributes"].instanceOffset.needsUpdate = true;
-            system.connector.geometry["attributes"].instanceRotation.needsUpdate = true;
-            system.bbconnector.geometry["attributes"].instanceOffset.needsUpdate = true;
-            system.bbconnector.geometry["attributes"].instanceRotation.needsUpdate = true;
-            system.bbconnector.geometry["attributes"].instanceScale.needsUpdate = true;
-            system.dummyBackbone.geometry["attributes"].instanceOffset.needsUpdate = true;
+            system.callUpdates(['instanceOffset','instanceRotation']);
         }
         centerAndPBC(system.getMonomers(), newBox);
         if (forceHandler) forceHandler.redraw();

--- a/ts/file_handling/io.ts
+++ b/ts/file_handling/io.ts
@@ -443,7 +443,7 @@ class TrajectoryReader {
                 currentNucleotide.calcPositionsFromConfLine(l, true);
             
                 //when a strand is finished, add it to the system
-                if (!currentNucleotide.n5 || currentNucleotide.n5 == currentStrand.end3) { //if last nucleotide in straight strand
+                if (currentStrand !== undefined && (!currentNucleotide.n5 || currentNucleotide.n5 == currentStrand.end3)) { //if last nucleotide in straight strand
                     if (currentNucleotide.n5 == currentStrand.end3) {
                         currentStrand.end5 = currentNucleotide;
                     }

--- a/ts/file_handling/ppio.ts
+++ b/ts/file_handling/ppio.ts
@@ -2,7 +2,7 @@
 
 class PatchyTopReader extends FileReader{
     topFile: File = null;
-    system: System;
+    system: PatchySystem;
     elems: ElementMap;
 
     sidCounter = 0;
@@ -13,7 +13,7 @@ class PatchyTopReader extends FileReader{
     configurationLength : number;
     LORO: boolean;
 
-    constructor(topFile: File, system: System, elems: ElementMap, callback : Function){
+    constructor(topFile: File, system: PatchySystem, elems: ElementMap, callback : Function){
         super();
         this.topFile = topFile;
         this.system = system;
@@ -22,7 +22,7 @@ class PatchyTopReader extends FileReader{
         this.LORO = false; 
         if(this.topFile.name.toLowerCase().includes("loro")) {
             this.LORO = true;
-        }    
+        }
     }
     onload = ((f) => {
         return () => {
@@ -31,58 +31,62 @@ class PatchyTopReader extends FileReader{
             let file = this.result as string
             let lines = file.split(/[\n]+/g);
 
-            
             this.configurationLength = parseInt(lines[0].split(" ")[0]);
             lines = lines.slice(1); // discard the header as we have the info now
 
+            let speciesCounts = [];
+
             if(!this.LORO){
-                let currentStrand = this.system.addNewPatchySphereStrand();
                 lines[0].split(" ").forEach((t,i)=>{
                     if(t){
-                        let sphere = currentStrand.createBasicElement(nucCount+i);
-                        sphere.sid = this.sidCounter++;
+                        let sphere = new PatchySphere(nucCount+i, this.system);
+                        this.system.particles.push(sphere);
                         sphere.id = i;
                         this.elems.set(nucCount+i, sphere);
 
                         sphere.type = t;
-                        sphere.clusterId = clusterCounter;
 
+                        const s = parseInt(t);
+                        if (speciesCounts[s] == undefined) {
+                            speciesCounts[s] = 1;
+                        } else {
+                            speciesCounts[s]++;
+                        }
+
+                        sphere.sid = speciesCounts[s]-1;
+                        sphere.clusterId = clusterCounter;
                     }
                 });
             }
-            else{
-                let currentStrand = this.system.addNewPatchySphereStrand();
+            else {
                 lines.forEach((line, t)=>{
                     console.log(line)
                     let info = line.split(" ");
                     const pcount = parseInt(info[0]);
                     for(let i = pcount * t; i < pcount * (t+1); i++){
 
-                        let sphere = currentStrand.createBasicElement(nucCount+i);
+                        let sphere = new PatchySphere(nucCount+i, this.system);
+                        this.system.particles.push(sphere);
                         sphere.sid = this.sidCounter++;
                         sphere.id = nucCount+i;
+                        sphere.sid = i;
                         this.elems.set(nucCount+i, sphere);
 
                         sphere.type = t.toString();
-                        sphere.clusterId = clusterCounter;
 
+                        // Set the id per species
+                        if (speciesCounts[t] == undefined) {
+                            speciesCounts[t] = 1;
+                        } else {
+                            speciesCounts[t]++;
+                        }
+
+                        sphere.sid = speciesCounts[t]-1;
+                        sphere.clusterId = clusterCounter;
                     }
                 });
             }
 
-            let particle = this.elems.get(nucCount);
-            particle.n5 = this.elems.get(nucCount+1);
-            for(let i = 1; i < this.configurationLength - 1; i++){
-                let particle =  this.elems.get(nucCount+i);
-                particle.n3 =  this.elems.get(nucCount + i -1);
-                particle.n5 =  this.elems.get(nucCount + i +1);
-            }
-            particle = this.elems.get(nucCount + this.configurationLength -1);
-            particle.n3 = this.elems.get(nucCount + this.configurationLength -2);
-
-
-            // Create new cluster for loaded structure:
-            let cluster = ++clusterCounter;
             nucCount = this.elems.getNextId();
             // usually the place where the DatReader gets fired
             this.callback();

--- a/ts/file_handling/ppio.ts
+++ b/ts/file_handling/ppio.ts
@@ -39,7 +39,7 @@ class PatchyTopReader extends FileReader{
             if(!this.LORO){
                 lines[0].split(" ").forEach((t,i)=>{
                     if(t){
-                        let sphere = new PatchySphere(nucCount+i, this.system);
+                        let sphere = new PatchyParticle(nucCount+i, this.system);
                         this.system.particles.push(sphere);
                         sphere.id = i;
                         this.elems.set(nucCount+i, sphere);
@@ -65,7 +65,7 @@ class PatchyTopReader extends FileReader{
                     const pcount = parseInt(info[0]);
                     for(let i = pcount * t; i < pcount * (t+1); i++){
 
-                        let sphere = new PatchySphere(nucCount+i, this.system);
+                        let sphere = new PatchyParticle(nucCount+i, this.system);
                         this.system.particles.push(sphere);
                         sphere.sid = this.sidCounter++;
                         sphere.id = nucCount+i;

--- a/ts/geometries/ConvexGeometry.js
+++ b/ts/geometries/ConvexGeometry.js
@@ -1,0 +1,48 @@
+( function () {
+
+	class ConvexGeometry extends THREE.BufferGeometry {
+
+		constructor( points ) {
+
+			super(); // buffers
+
+			const vertices = [];
+			const normals = [];
+
+			if ( THREE.ConvexHull === undefined ) {
+
+				console.error( 'THREE.ConvexBufferGeometry: ConvexBufferGeometry relies on THREE.ConvexHull' );
+
+			}
+
+			const convexHull = new THREE.ConvexHull().setFromPoints( points ); // generate vertices and normals
+
+			const faces = convexHull.faces;
+
+			for ( let i = 0; i < faces.length; i ++ ) {
+
+				const face = faces[ i ];
+				let edge = face.edge; // we move along a doubly-connected edge list to access all face points (see HalfEdge docs)
+
+				do {
+
+					const point = edge.head().point;
+					vertices.push( point.x, point.y, point.z );
+					normals.push( face.normal.x, face.normal.y, face.normal.z );
+					edge = edge.next;
+
+				} while ( edge !== face.edge );
+
+			} // build geometry
+
+
+			this.setAttribute( 'position', new THREE.Float32BufferAttribute( vertices, 3 ) );
+			this.setAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
+
+		}
+
+	}
+
+	THREE.ConvexGeometry = ConvexGeometry;
+
+} )();

--- a/ts/geometries/ConvexGeometry.js
+++ b/ts/geometries/ConvexGeometry.js
@@ -36,8 +36,11 @@
 			} // build geometry
 
 
-			this.setAttribute( 'position', new THREE.Float32BufferAttribute( vertices, 3 ) );
-			this.setAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
+			// Why this hack?
+			//this.setAttribute( 'position', new THREE.Float32BufferAttribute( vertices, 3 ) );
+			//this.setAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
+			this.addAttribute( 'position', new THREE.Float32BufferAttribute( vertices, 3 ) );
+			this.addAttribute( 'normal', new THREE.Float32BufferAttribute( normals, 3 ) );
 
 		}
 

--- a/ts/geometries/ConvexHull.js
+++ b/ts/geometries/ConvexHull.js
@@ -1,0 +1,1125 @@
+( function () {
+
+	/**
+ * Ported from: https://github.com/maurizzzio/quickhull3d/ by Mauricio Poppe (https://github.com/maurizzzio)
+ */
+
+	const Visible = 0;
+	const Deleted = 1;
+
+	const _v1 = new THREE.Vector3();
+
+	const _line3 = new THREE.Line3();
+
+	const _plane = new THREE.Plane();
+
+	const _closestPoint = new THREE.Vector3();
+
+	const _triangle = new THREE.Triangle();
+
+	class ConvexHull {
+
+		constructor() {
+
+			this.tolerance = - 1;
+			this.faces = []; // the generated faces of the convex hull
+
+			this.newFaces = []; // this array holds the faces that are generated within a single iteration
+			// the vertex lists work as follows:
+			//
+			// let 'a' and 'b' be 'Face' instances
+			// let 'v' be points wrapped as instance of 'Vertex'
+			//
+			//     [v, v, ..., v, v, v, ...]
+			//      ^             ^
+			//      |             |
+			//  a.outside     b.outside
+			//
+
+			this.assigned = new VertexList();
+			this.unassigned = new VertexList();
+			this.vertices = []; // vertices of the hull (internal representation of given geometry data)
+
+		}
+
+		setFromPoints( points ) {
+
+			if ( Array.isArray( points ) !== true ) {
+
+				console.error( 'THREE.ConvexHull: Points parameter is not an array.' );
+
+			}
+
+			if ( points.length < 4 ) {
+
+				console.error( 'THREE.ConvexHull: The algorithm needs at least four points.' );
+
+			}
+
+			this.makeEmpty();
+
+			for ( let i = 0, l = points.length; i < l; i ++ ) {
+
+				this.vertices.push( new VertexNode( points[ i ] ) );
+
+			}
+
+			this.compute();
+			return this;
+
+		}
+
+		setFromObject( object ) {
+
+			const points = [];
+			object.updateMatrixWorld( true );
+			object.traverse( function ( node ) {
+
+				const geometry = node.geometry;
+
+				if ( geometry !== undefined ) {
+
+					if ( geometry.isGeometry ) {
+
+						console.error( 'THREE.ConvexHull no longer supports Geometry. Use THREE.BufferGeometry instead.' );
+						return;
+
+					} else if ( geometry.isBufferGeometry ) {
+
+						const attribute = geometry.attributes.position;
+
+						if ( attribute !== undefined ) {
+
+							for ( let i = 0, l = attribute.count; i < l; i ++ ) {
+
+								const point = new THREE.Vector3();
+								point.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
+								points.push( point );
+
+							}
+
+						}
+
+					}
+
+				}
+
+			} );
+			return this.setFromPoints( points );
+
+		}
+
+		containsPoint( point ) {
+
+			const faces = this.faces;
+
+			for ( let i = 0, l = faces.length; i < l; i ++ ) {
+
+				const face = faces[ i ]; // compute signed distance and check on what half space the point lies
+
+				if ( face.distanceToPoint( point ) > this.tolerance ) return false;
+
+			}
+
+			return true;
+
+		}
+
+		intersectRay( ray, target ) {
+
+			// based on "Fast Ray-Convex Polyhedron Intersection"  by Eric Haines, GRAPHICS GEMS II
+			const faces = this.faces;
+			let tNear = - Infinity;
+			let tFar = Infinity;
+
+			for ( let i = 0, l = faces.length; i < l; i ++ ) {
+
+				const face = faces[ i ]; // interpret faces as planes for the further computation
+
+				const vN = face.distanceToPoint( ray.origin );
+				const vD = face.normal.dot( ray.direction ); // if the origin is on the positive side of a plane (so the plane can "see" the origin) and
+				// the ray is turned away or parallel to the plane, there is no intersection
+
+				if ( vN > 0 && vD >= 0 ) return null; // compute the distance from the ray’s origin to the intersection with the plane
+
+				const t = vD !== 0 ? - vN / vD : 0; // only proceed if the distance is positive. a negative distance means the intersection point
+				// lies "behind" the origin
+
+				if ( t <= 0 ) continue; // now categorized plane as front-facing or back-facing
+
+				if ( vD > 0 ) {
+
+					//  plane faces away from the ray, so this plane is a back-face
+					tFar = Math.min( t, tFar );
+
+				} else {
+
+					// front-face
+					tNear = Math.max( t, tNear );
+
+				}
+
+				if ( tNear > tFar ) {
+
+					// if tNear ever is greater than tFar, the ray must miss the convex hull
+					return null;
+
+				}
+
+			} // evaluate intersection point
+			// always try tNear first since its the closer intersection point
+
+
+			if ( tNear !== - Infinity ) {
+
+				ray.at( tNear, target );
+
+			} else {
+
+				ray.at( tFar, target );
+
+			}
+
+			return target;
+
+		}
+
+		intersectsRay( ray ) {
+
+			return this.intersectRay( ray, _v1 ) !== null;
+
+		}
+
+		makeEmpty() {
+
+			this.faces = [];
+			this.vertices = [];
+			return this;
+
+		} // Adds a vertex to the 'assigned' list of vertices and assigns it to the given face
+
+
+		addVertexToFace( vertex, face ) {
+
+			vertex.face = face;
+
+			if ( face.outside === null ) {
+
+				this.assigned.append( vertex );
+
+			} else {
+
+				this.assigned.insertBefore( face.outside, vertex );
+
+			}
+
+			face.outside = vertex;
+			return this;
+
+		} // Removes a vertex from the 'assigned' list of vertices and from the given face
+
+
+		removeVertexFromFace( vertex, face ) {
+
+			if ( vertex === face.outside ) {
+
+				// fix face.outside link
+				if ( vertex.next !== null && vertex.next.face === face ) {
+
+					// face has at least 2 outside vertices, move the 'outside' reference
+					face.outside = vertex.next;
+
+				} else {
+
+					// vertex was the only outside vertex that face had
+					face.outside = null;
+
+				}
+
+			}
+
+			this.assigned.remove( vertex );
+			return this;
+
+		} // Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list
+
+
+		removeAllVerticesFromFace( face ) {
+
+			if ( face.outside !== null ) {
+
+				// reference to the first and last vertex of this face
+				const start = face.outside;
+				let end = face.outside;
+
+				while ( end.next !== null && end.next.face === face ) {
+
+					end = end.next;
+
+				}
+
+				this.assigned.removeSubList( start, end ); // fix references
+
+				start.prev = end.next = null;
+				face.outside = null;
+				return start;
+
+			}
+
+		} // Removes all the visible vertices that 'face' is able to see
+
+
+		deleteFaceVertices( face, absorbingFace ) {
+
+			const faceVertices = this.removeAllVerticesFromFace( face );
+
+			if ( faceVertices !== undefined ) {
+
+				if ( absorbingFace === undefined ) {
+
+					// mark the vertices to be reassigned to some other face
+					this.unassigned.appendChain( faceVertices );
+
+				} else {
+
+					// if there's an absorbing face try to assign as many vertices as possible to it
+					let vertex = faceVertices;
+
+					do {
+
+						// we need to buffer the subsequent vertex at this point because the 'vertex.next' reference
+						// will be changed by upcoming method calls
+						const nextVertex = vertex.next;
+						const distance = absorbingFace.distanceToPoint( vertex.point ); // check if 'vertex' is able to see 'absorbingFace'
+
+						if ( distance > this.tolerance ) {
+
+							this.addVertexToFace( vertex, absorbingFace );
+
+						} else {
+
+							this.unassigned.append( vertex );
+
+						} // now assign next vertex
+
+
+						vertex = nextVertex;
+
+					} while ( vertex !== null );
+
+				}
+
+			}
+
+			return this;
+
+		} // Reassigns as many vertices as possible from the unassigned list to the new faces
+
+
+		resolveUnassignedPoints( newFaces ) {
+
+			if ( this.unassigned.isEmpty() === false ) {
+
+				let vertex = this.unassigned.first();
+
+				do {
+
+					// buffer 'next' reference, see .deleteFaceVertices()
+					const nextVertex = vertex.next;
+					let maxDistance = this.tolerance;
+					let maxFace = null;
+
+					for ( let i = 0; i < newFaces.length; i ++ ) {
+
+						const face = newFaces[ i ];
+
+						if ( face.mark === Visible ) {
+
+							const distance = face.distanceToPoint( vertex.point );
+
+							if ( distance > maxDistance ) {
+
+								maxDistance = distance;
+								maxFace = face;
+
+							}
+
+							if ( maxDistance > 1000 * this.tolerance ) break;
+
+						}
+
+					} // 'maxFace' can be null e.g. if there are identical vertices
+
+
+					if ( maxFace !== null ) {
+
+						this.addVertexToFace( vertex, maxFace );
+
+					}
+
+					vertex = nextVertex;
+
+				} while ( vertex !== null );
+
+			}
+
+			return this;
+
+		} // Computes the extremes of a simplex which will be the initial hull
+
+
+		computeExtremes() {
+
+			const min = new THREE.Vector3();
+			const max = new THREE.Vector3();
+			const minVertices = [];
+			const maxVertices = []; // initially assume that the first vertex is the min/max
+
+			for ( let i = 0; i < 3; i ++ ) {
+
+				minVertices[ i ] = maxVertices[ i ] = this.vertices[ 0 ];
+
+			}
+
+			min.copy( this.vertices[ 0 ].point );
+			max.copy( this.vertices[ 0 ].point ); // compute the min/max vertex on all six directions
+
+			for ( let i = 0, l = this.vertices.length; i < l; i ++ ) {
+
+				const vertex = this.vertices[ i ];
+				const point = vertex.point; // update the min coordinates
+
+				for ( let j = 0; j < 3; j ++ ) {
+
+					if ( point.getComponent( j ) < min.getComponent( j ) ) {
+
+						min.setComponent( j, point.getComponent( j ) );
+						minVertices[ j ] = vertex;
+
+					}
+
+				} // update the max coordinates
+
+
+				for ( let j = 0; j < 3; j ++ ) {
+
+					if ( point.getComponent( j ) > max.getComponent( j ) ) {
+
+						max.setComponent( j, point.getComponent( j ) );
+						maxVertices[ j ] = vertex;
+
+					}
+
+				}
+
+			} // use min/max vectors to compute an optimal epsilon
+
+
+			this.tolerance = 3 * Number.EPSILON * ( Math.max( Math.abs( min.x ), Math.abs( max.x ) ) + Math.max( Math.abs( min.y ), Math.abs( max.y ) ) + Math.max( Math.abs( min.z ), Math.abs( max.z ) ) );
+			return {
+				min: minVertices,
+				max: maxVertices
+			};
+
+		} // Computes the initial simplex assigning to its faces all the points
+		// that are candidates to form part of the hull
+
+
+		computeInitialHull() {
+
+			const vertices = this.vertices;
+			const extremes = this.computeExtremes();
+			const min = extremes.min;
+			const max = extremes.max; // 1. Find the two vertices 'v0' and 'v1' with the greatest 1d separation
+			// (max.x - min.x)
+			// (max.y - min.y)
+			// (max.z - min.z)
+
+			let maxDistance = 0;
+			let index = 0;
+
+			for ( let i = 0; i < 3; i ++ ) {
+
+				const distance = max[ i ].point.getComponent( i ) - min[ i ].point.getComponent( i );
+
+				if ( distance > maxDistance ) {
+
+					maxDistance = distance;
+					index = i;
+
+				}
+
+			}
+
+			const v0 = min[ index ];
+			const v1 = max[ index ];
+			let v2;
+			let v3; // 2. The next vertex 'v2' is the one farthest to the line formed by 'v0' and 'v1'
+
+			maxDistance = 0;
+
+			_line3.set( v0.point, v1.point );
+
+			for ( let i = 0, l = this.vertices.length; i < l; i ++ ) {
+
+				const vertex = vertices[ i ];
+
+				if ( vertex !== v0 && vertex !== v1 ) {
+
+					_line3.closestPointToPoint( vertex.point, true, _closestPoint );
+
+					const distance = _closestPoint.distanceToSquared( vertex.point );
+
+					if ( distance > maxDistance ) {
+
+						maxDistance = distance;
+						v2 = vertex;
+
+					}
+
+				}
+
+			} // 3. The next vertex 'v3' is the one farthest to the plane 'v0', 'v1', 'v2'
+
+
+			maxDistance = - 1;
+
+			_plane.setFromCoplanarPoints( v0.point, v1.point, v2.point );
+
+			for ( let i = 0, l = this.vertices.length; i < l; i ++ ) {
+
+				const vertex = vertices[ i ];
+
+				if ( vertex !== v0 && vertex !== v1 && vertex !== v2 ) {
+
+					const distance = Math.abs( _plane.distanceToPoint( vertex.point ) );
+
+					if ( distance > maxDistance ) {
+
+						maxDistance = distance;
+						v3 = vertex;
+
+					}
+
+				}
+
+			}
+
+			const faces = [];
+
+			if ( _plane.distanceToPoint( v3.point ) < 0 ) {
+
+				// the face is not able to see the point so 'plane.normal' is pointing outside the tetrahedron
+				faces.push( Face.create( v0, v1, v2 ), Face.create( v3, v1, v0 ), Face.create( v3, v2, v1 ), Face.create( v3, v0, v2 ) ); // set the twin edge
+
+				for ( let i = 0; i < 3; i ++ ) {
+
+					const j = ( i + 1 ) % 3; // join face[ i ] i > 0, with the first face
+
+					faces[ i + 1 ].getEdge( 2 ).setTwin( faces[ 0 ].getEdge( j ) ); // join face[ i ] with face[ i + 1 ], 1 <= i <= 3
+
+					faces[ i + 1 ].getEdge( 1 ).setTwin( faces[ j + 1 ].getEdge( 0 ) );
+
+				}
+
+			} else {
+
+				// the face is able to see the point so 'plane.normal' is pointing inside the tetrahedron
+				faces.push( Face.create( v0, v2, v1 ), Face.create( v3, v0, v1 ), Face.create( v3, v1, v2 ), Face.create( v3, v2, v0 ) ); // set the twin edge
+
+				for ( let i = 0; i < 3; i ++ ) {
+
+					const j = ( i + 1 ) % 3; // join face[ i ] i > 0, with the first face
+
+					faces[ i + 1 ].getEdge( 2 ).setTwin( faces[ 0 ].getEdge( ( 3 - i ) % 3 ) ); // join face[ i ] with face[ i + 1 ]
+
+					faces[ i + 1 ].getEdge( 0 ).setTwin( faces[ j + 1 ].getEdge( 1 ) );
+
+				}
+
+			} // the initial hull is the tetrahedron
+
+
+			for ( let i = 0; i < 4; i ++ ) {
+
+				this.faces.push( faces[ i ] );
+
+			} // initial assignment of vertices to the faces of the tetrahedron
+
+
+			for ( let i = 0, l = vertices.length; i < l; i ++ ) {
+
+				const vertex = vertices[ i ];
+
+				if ( vertex !== v0 && vertex !== v1 && vertex !== v2 && vertex !== v3 ) {
+
+					maxDistance = this.tolerance;
+					let maxFace = null;
+
+					for ( let j = 0; j < 4; j ++ ) {
+
+						const distance = this.faces[ j ].distanceToPoint( vertex.point );
+
+						if ( distance > maxDistance ) {
+
+							maxDistance = distance;
+							maxFace = this.faces[ j ];
+
+						}
+
+					}
+
+					if ( maxFace !== null ) {
+
+						this.addVertexToFace( vertex, maxFace );
+
+					}
+
+				}
+
+			}
+
+			return this;
+
+		} // Removes inactive faces
+
+
+		reindexFaces() {
+
+			const activeFaces = [];
+
+			for ( let i = 0; i < this.faces.length; i ++ ) {
+
+				const face = this.faces[ i ];
+
+				if ( face.mark === Visible ) {
+
+					activeFaces.push( face );
+
+				}
+
+			}
+
+			this.faces = activeFaces;
+			return this;
+
+		} // Finds the next vertex to create faces with the current hull
+
+
+		nextVertexToAdd() {
+
+			// if the 'assigned' list of vertices is empty, no vertices are left. return with 'undefined'
+			if ( this.assigned.isEmpty() === false ) {
+
+				let eyeVertex,
+					maxDistance = 0; // grap the first available face and start with the first visible vertex of that face
+
+				const eyeFace = this.assigned.first().face;
+				let vertex = eyeFace.outside; // now calculate the farthest vertex that face can see
+
+				do {
+
+					const distance = eyeFace.distanceToPoint( vertex.point );
+
+					if ( distance > maxDistance ) {
+
+						maxDistance = distance;
+						eyeVertex = vertex;
+
+					}
+
+					vertex = vertex.next;
+
+				} while ( vertex !== null && vertex.face === eyeFace );
+
+				return eyeVertex;
+
+			}
+
+		} // Computes a chain of half edges in CCW order called the 'horizon'.
+		// For an edge to be part of the horizon it must join a face that can see
+		// 'eyePoint' and a face that cannot see 'eyePoint'.
+
+
+		computeHorizon( eyePoint, crossEdge, face, horizon ) {
+
+			// moves face's vertices to the 'unassigned' vertex list
+			this.deleteFaceVertices( face );
+			face.mark = Deleted;
+			let edge;
+
+			if ( crossEdge === null ) {
+
+				edge = crossEdge = face.getEdge( 0 );
+
+			} else {
+
+				// start from the next edge since 'crossEdge' was already analyzed
+				// (actually 'crossEdge.twin' was the edge who called this method recursively)
+				edge = crossEdge.next;
+
+			}
+
+			do {
+
+				const twinEdge = edge.twin;
+				const oppositeFace = twinEdge.face;
+
+				if ( oppositeFace.mark === Visible ) {
+
+					if ( oppositeFace.distanceToPoint( eyePoint ) > this.tolerance ) {
+
+						// the opposite face can see the vertex, so proceed with next edge
+						this.computeHorizon( eyePoint, twinEdge, oppositeFace, horizon );
+
+					} else {
+
+						// the opposite face can't see the vertex, so this edge is part of the horizon
+						horizon.push( edge );
+
+					}
+
+				}
+
+				edge = edge.next;
+
+			} while ( edge !== crossEdge );
+
+			return this;
+
+		} // Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order
+
+
+		addAdjoiningFace( eyeVertex, horizonEdge ) {
+
+			// all the half edges are created in ccw order thus the face is always pointing outside the hull
+			const face = Face.create( eyeVertex, horizonEdge.tail(), horizonEdge.head() );
+			this.faces.push( face ); // join face.getEdge( - 1 ) with the horizon's opposite edge face.getEdge( - 1 ) = face.getEdge( 2 )
+
+			face.getEdge( - 1 ).setTwin( horizonEdge.twin );
+			return face.getEdge( 0 ); // the half edge whose vertex is the eyeVertex
+
+		} //  Adds 'horizon.length' faces to the hull, each face will be linked with the
+		//  horizon opposite face and the face on the left/right
+
+
+		addNewFaces( eyeVertex, horizon ) {
+
+			this.newFaces = [];
+			let firstSideEdge = null;
+			let previousSideEdge = null;
+
+			for ( let i = 0; i < horizon.length; i ++ ) {
+
+				const horizonEdge = horizon[ i ]; // returns the right side edge
+
+				const sideEdge = this.addAdjoiningFace( eyeVertex, horizonEdge );
+
+				if ( firstSideEdge === null ) {
+
+					firstSideEdge = sideEdge;
+
+				} else {
+
+					// joins face.getEdge( 1 ) with previousFace.getEdge( 0 )
+					sideEdge.next.setTwin( previousSideEdge );
+
+				}
+
+				this.newFaces.push( sideEdge.face );
+				previousSideEdge = sideEdge;
+
+			} // perform final join of new faces
+
+
+			firstSideEdge.next.setTwin( previousSideEdge );
+			return this;
+
+		} // Adds a vertex to the hull
+
+
+		addVertexToHull( eyeVertex ) {
+
+			const horizon = [];
+			this.unassigned.clear(); // remove 'eyeVertex' from 'eyeVertex.face' so that it can't be added to the 'unassigned' vertex list
+
+			this.removeVertexFromFace( eyeVertex, eyeVertex.face );
+			this.computeHorizon( eyeVertex.point, null, eyeVertex.face, horizon );
+			this.addNewFaces( eyeVertex, horizon ); // reassign 'unassigned' vertices to the new faces
+
+			this.resolveUnassignedPoints( this.newFaces );
+			return this;
+
+		}
+
+		cleanup() {
+
+			this.assigned.clear();
+			this.unassigned.clear();
+			this.newFaces = [];
+			return this;
+
+		}
+
+		compute() {
+
+			let vertex;
+			this.computeInitialHull(); // add all available vertices gradually to the hull
+
+			while ( ( vertex = this.nextVertexToAdd() ) !== undefined ) {
+
+				this.addVertexToHull( vertex );
+
+			}
+
+			this.reindexFaces();
+			this.cleanup();
+			return this;
+
+		}
+
+	} //
+
+
+	class Face {
+
+		constructor() {
+
+			this.normal = new THREE.Vector3();
+			this.midpoint = new THREE.Vector3();
+			this.area = 0;
+			this.constant = 0; // signed distance from face to the origin
+
+			this.outside = null; // reference to a vertex in a vertex list this face can see
+
+			this.mark = Visible;
+			this.edge = null;
+
+		}
+
+		static create( a, b, c ) {
+
+			const face = new Face();
+			const e0 = new HalfEdge( a, face );
+			const e1 = new HalfEdge( b, face );
+			const e2 = new HalfEdge( c, face ); // join edges
+
+			e0.next = e2.prev = e1;
+			e1.next = e0.prev = e2;
+			e2.next = e1.prev = e0; // main half edge reference
+
+			face.edge = e0;
+			return face.compute();
+
+		}
+
+		getEdge( i ) {
+
+			let edge = this.edge;
+
+			while ( i > 0 ) {
+
+				edge = edge.next;
+				i --;
+
+			}
+
+			while ( i < 0 ) {
+
+				edge = edge.prev;
+				i ++;
+
+			}
+
+			return edge;
+
+		}
+
+		compute() {
+
+			const a = this.edge.tail();
+			const b = this.edge.head();
+			const c = this.edge.next.head();
+
+			_triangle.set( a.point, b.point, c.point );
+
+			_triangle.getNormal( this.normal );
+
+			_triangle.getMidpoint( this.midpoint );
+
+			this.area = _triangle.getArea();
+			this.constant = this.normal.dot( this.midpoint );
+			return this;
+
+		}
+
+		distanceToPoint( point ) {
+
+			return this.normal.dot( point ) - this.constant;
+
+		}
+
+	} // Entity for a Doubly-Connected Edge List (DCEL).
+
+
+	class HalfEdge {
+
+		constructor( vertex, face ) {
+
+			this.vertex = vertex;
+			this.prev = null;
+			this.next = null;
+			this.twin = null;
+			this.face = face;
+
+		}
+
+		head() {
+
+			return this.vertex;
+
+		}
+
+		tail() {
+
+			return this.prev ? this.prev.vertex : null;
+
+		}
+
+		length() {
+
+			const head = this.head();
+			const tail = this.tail();
+
+			if ( tail !== null ) {
+
+				return tail.point.distanceTo( head.point );
+
+			}
+
+			return - 1;
+
+		}
+
+		lengthSquared() {
+
+			const head = this.head();
+			const tail = this.tail();
+
+			if ( tail !== null ) {
+
+				return tail.point.distanceToSquared( head.point );
+
+			}
+
+			return - 1;
+
+		}
+
+		setTwin( edge ) {
+
+			this.twin = edge;
+			edge.twin = this;
+			return this;
+
+		}
+
+	} // A vertex as a double linked list node.
+
+
+	class VertexNode {
+
+		constructor( point ) {
+
+			this.point = point;
+			this.prev = null;
+			this.next = null;
+			this.face = null; // the face that is able to see this vertex
+
+		}
+
+	} // A double linked list that contains vertex nodes.
+
+
+	class VertexList {
+
+		constructor() {
+
+			this.head = null;
+			this.tail = null;
+
+		}
+
+		first() {
+
+			return this.head;
+
+		}
+
+		last() {
+
+			return this.tail;
+
+		}
+
+		clear() {
+
+			this.head = this.tail = null;
+			return this;
+
+		} // Inserts a vertex before the target vertex
+
+
+		insertBefore( target, vertex ) {
+
+			vertex.prev = target.prev;
+			vertex.next = target;
+
+			if ( vertex.prev === null ) {
+
+				this.head = vertex;
+
+			} else {
+
+				vertex.prev.next = vertex;
+
+			}
+
+			target.prev = vertex;
+			return this;
+
+		} // Inserts a vertex after the target vertex
+
+
+		insertAfter( target, vertex ) {
+
+			vertex.prev = target;
+			vertex.next = target.next;
+
+			if ( vertex.next === null ) {
+
+				this.tail = vertex;
+
+			} else {
+
+				vertex.next.prev = vertex;
+
+			}
+
+			target.next = vertex;
+			return this;
+
+		} // Appends a vertex to the end of the linked list
+
+
+		append( vertex ) {
+
+			if ( this.head === null ) {
+
+				this.head = vertex;
+
+			} else {
+
+				this.tail.next = vertex;
+
+			}
+
+			vertex.prev = this.tail;
+			vertex.next = null; // the tail has no subsequent vertex
+
+			this.tail = vertex;
+			return this;
+
+		} // Appends a chain of vertices where 'vertex' is the head.
+
+
+		appendChain( vertex ) {
+
+			if ( this.head === null ) {
+
+				this.head = vertex;
+
+			} else {
+
+				this.tail.next = vertex;
+
+			}
+
+			vertex.prev = this.tail; // ensure that the 'tail' reference points to the last vertex of the chain
+
+			while ( vertex.next !== null ) {
+
+				vertex = vertex.next;
+
+			}
+
+			this.tail = vertex;
+			return this;
+
+		} // Removes a vertex from the linked list
+
+
+		remove( vertex ) {
+
+			if ( vertex.prev === null ) {
+
+				this.head = vertex.next;
+
+			} else {
+
+				vertex.prev.next = vertex.next;
+
+			}
+
+			if ( vertex.next === null ) {
+
+				this.tail = vertex.prev;
+
+			} else {
+
+				vertex.next.prev = vertex.prev;
+
+			}
+
+			return this;
+
+		} // Removes a list of vertices whose 'head' is 'a' and whose 'tail' is b
+
+
+		removeSubList( a, b ) {
+
+			if ( a.prev === null ) {
+
+				this.head = b.next;
+
+			} else {
+
+				a.prev.next = b.next;
+
+			}
+
+			if ( b.next === null ) {
+
+				this.tail = a.prev;
+
+			} else {
+
+				b.next.prev = a.prev;
+
+			}
+
+			return this;
+
+		}
+
+		isEmpty() {
+
+			return this.head === null;
+
+		}
+
+	}
+
+	THREE.ConvexHull = ConvexHull;
+
+} )();

--- a/ts/geometries/three-convexgeometry.d.ts
+++ b/ts/geometries/three-convexgeometry.d.ts
@@ -1,0 +1,5 @@
+import { BufferGeometry, Vector3 } from "../lib/three-core";
+
+export class ConvexGeometry extends BufferGeometry {
+    constructor(points: Vector3[]);
+}

--- a/ts/model/basicElement.ts
+++ b/ts/model/basicElement.ts
@@ -216,6 +216,10 @@ abstract class BasicElement {
         return false;
     }
 
+    isPatchyParticle() {
+        return false;
+    }
+
     toJSON() {
         // Specify required attributes
         let json = {

--- a/ts/model/genericSphere.ts
+++ b/ts/model/genericSphere.ts
@@ -277,37 +277,49 @@ class PatchySphere extends GenericSphere{
             parseFloat(l[2])
         );
 
-        // extract axis vector a1 (backbone vector) and a3 (stacking vector) 
+        //extract orientation vectors
         let a1 = new THREE.Vector3(
             parseFloat(l[3]),
             parseFloat(l[4]),
             parseFloat(l[5])
-        );
+        ).normalize();
+
         let a3 = new THREE.Vector3(
             parseFloat(l[6]),
             parseFloat(l[7]),
             parseFloat(l[8])
-        );
+        ).normalize();
+
         this.calcPositions(p, a1, a3, colorUpdate)
     };
 
-    calcPositions(p: THREE.Vector3, a1?: THREE.Vector3, a3?: THREE.Vector3, colorUpdate?: boolean) { //mass Parameter should be set prior to calling this
+    calcPositions(p: THREE.Vector3, a1?: THREE.Vector3, a3?: THREE.Vector3, _colorUpdate?: boolean) {
         let sid = this.sid;
   
         let idColor = new THREE.Color();
         idColor.setHex(this.id + 1); //has to be +1 or you can't grab nucleotide 0
-        // fill in the instancing matrices
-        let scale;
-        if(this.mass > 4){ //More than 4 particles
-            scale = 1+this.mass/16;
-        } else {
-            scale = 1;
-        }
 
-        let q = rotateVectorsSimultaneously(
-            new THREE.Vector3(0, 0, 1), new THREE.Vector3(1, 0, 0),
-            a3, a1
-        );
+        //p.y *= -1;
+        //p.z *= -1;
+
+        //a1.y *= -1;
+        //a1.z *= -1;
+
+        //a3.y *= -1;
+        //a3.z *= -1;
+
+        let scale = 1;
+
+        const defaultA1 = new THREE.Vector3(1, 0, 0);
+        const defaultA3 = new THREE.Vector3(0, 0, 1);
+
+        const q = rotateVectorsSimultaneously(
+            defaultA1, defaultA3,
+            a1.clone(), a3.clone()
+        )
+
+        console.assert(defaultA1.clone().applyQuaternion(q).distanceTo(a1) < 1e-5, "a1 wrong");
+        console.assert(defaultA3.clone().applyQuaternion(q).distanceTo(a3) < 1e-5, "a3 wrong");
 
         let species = parseInt(this.type);
 
@@ -315,15 +327,22 @@ class PatchySphere extends GenericSphere{
         this.system.fillPatchyVec(species,'rotations', 4, sid, [q.w, q.z, q.y, q.x]);
         this.system.fillPatchyVec(species,'visibilities', 3, sid, [1, 1, 1]);
         this.system.fillPatchyVec(species,'scalings', 3, sid, [scale, scale, scale]);
+
         let color = this.elemToColor(this.type);
         this.system.fillPatchyVec(species,'colors', 3, sid, [color.r, color.g, color.b]);
     }
 }
 
+//https://stackoverflow.com/a/55248720
+//https://robokitchen.tumblr.com/post/67060392720/finding-a-quaternion-from-two-pairs-of-vectors
 function rotateVectorsSimultaneously(
-    u0: THREE.Vector3, v0: THREE.Vector3,
+    u0: THREE.Vector3, v0: THREE.Vector3, 
     u2: THREE.Vector3, v2: THREE.Vector3
-    ): THREE.Quaternion {
+): THREE.Quaternion {
+    u0.normalize();
+    v0.normalize();
+    u2.normalize();
+    v2.normalize();
     const q2 = new THREE.Quaternion().setFromUnitVectors(u0, u2);
 
     const v1 = v2.clone().applyQuaternion(q2.clone().conjugate());

--- a/ts/model/genericSphere.ts
+++ b/ts/model/genericSphere.ts
@@ -313,13 +313,20 @@ class PatchySphere extends GenericSphere{
         const defaultA1 = new THREE.Vector3(1, 0, 0);
         const defaultA3 = new THREE.Vector3(0, 0, 1);
 
+
         const q = rotateVectorsSimultaneously(
             defaultA1, defaultA3,
             a1.clone(), a3.clone()
-        )
+        );
+
+        //const q = new THREE.Quaternion();
 
         console.assert(defaultA1.clone().applyQuaternion(q).distanceTo(a1) < 1e-5, "a1 wrong");
         console.assert(defaultA3.clone().applyQuaternion(q).distanceTo(a3) < 1e-5, "a3 wrong");
+
+        // For some reason, we have to rotate the orientations
+        // around an axis with inverted y-value...
+        q.y *= -1;
 
         let species = parseInt(this.type);
 
@@ -347,8 +354,8 @@ function rotateVectorsSimultaneously(
 
     const v1 = v2.clone().applyQuaternion(q2.clone().conjugate());
 
-    const v0_proj = v0.projectOnPlane(u0);
-    const v1_proj = v1.projectOnPlane(u0);
+    const v0_proj = v0.clone().projectOnPlane(u0);
+    const v1_proj = v1.clone().projectOnPlane(u0);
 
     let angleInPlane = v0_proj.angleTo(v1_proj);
     if (v1_proj.dot(new THREE.Vector3().crossVectors(u0, v0)) < 0) {

--- a/ts/model/genericSphere.ts
+++ b/ts/model/genericSphere.ts
@@ -299,15 +299,6 @@ class PatchySphere extends GenericSphere{
         let idColor = new THREE.Color();
         idColor.setHex(this.id + 1); //has to be +1 or you can't grab nucleotide 0
 
-        //p.y *= -1;
-        //p.z *= -1;
-
-        //a1.y *= -1;
-        //a1.z *= -1;
-
-        //a3.y *= -1;
-        //a3.z *= -1;
-
         let scale = 1;
 
         const defaultA1 = new THREE.Vector3(1, 0, 0);

--- a/ts/model/genericSphere.ts
+++ b/ts/model/genericSphere.ts
@@ -310,8 +310,6 @@ class PatchySphere extends GenericSphere{
             a1.clone(), a3.clone()
         );
 
-        //const q = new THREE.Quaternion();
-
         console.assert(defaultA1.clone().applyQuaternion(q).distanceTo(a1) < 1e-5, "a1 wrong");
         console.assert(defaultA3.clone().applyQuaternion(q).distanceTo(a3) < 1e-5, "a3 wrong");
 

--- a/ts/model/genericSphere.ts
+++ b/ts/model/genericSphere.ts
@@ -218,7 +218,7 @@ class GenericSphere extends BasicElement {
 }
 
 
-class PatchySphere extends GenericSphere{
+class PatchyParticle extends GenericSphere{
     system: PatchySystem;
 
     constructor(id, system) {
@@ -295,9 +295,6 @@ class PatchySphere extends GenericSphere{
 
     calcPositions(p: THREE.Vector3, a1?: THREE.Vector3, a3?: THREE.Vector3, _colorUpdate?: boolean) {
         let sid = this.sid;
-  
-        let idColor = new THREE.Color();
-        idColor.setHex(this.id + 1); //has to be +1 or you can't grab nucleotide 0
 
         let scale = 1;
 
@@ -326,6 +323,56 @@ class PatchySphere extends GenericSphere{
 
         let color = this.elemToColor(this.type);
         this.system.fillPatchyVec(species,'colors', 3, sid, [color.r, color.g, color.b]);
+
+        let idColor = new THREE.Color();
+        idColor.setHex(this.id + 1); //has to be +1 or you can't grab nucleotide 0
+        this.system.fillPatchyVec(species,'labels', 3, sid, [idColor.r, idColor.g, idColor.b]);
+    }
+
+    updateColor() {
+        let color: THREE.Color;
+        switch (view.coloringMode.get()) {
+            case "System":
+                color = backboneColors[this.getSystem().id % backboneColors.length];
+                break;
+            case "Cluster":
+                if (!this.clusterId || this.clusterId < 0) {
+                    color = new THREE.Color(0xE60A0A);
+                }
+                else {
+                    color = backboneColors[this.clusterId % backboneColors.length];
+                }
+                break;
+            case "Overlay":
+                color = this.system.lutCols[this.sid];
+                break;
+            case "Custom":
+                if (!this.color) {
+                    // Use overlay color if overlay is loaded, otherwise color gray
+                    if (lut) {
+                        color = this.system.lutCols[this.sid];
+                    } else {
+                        color = GREY;
+                    }
+                }
+                else {
+                    color = this.color;
+                }
+                break;
+            default:
+                color = this.elemToColor(this.type)
+                break;
+        }
+        if (selectedBases.has(this)) {
+            color = color.clone().lerp(selectionColor, 0.6).multiplyScalar(2);
+        }
+
+        let species = parseInt(this.type);
+        this.system.fillPatchyVec(species,'colors', 3, this.sid, [color.r, color.g, color.b]);
+    }
+
+    isPatchyParticle() {
+        return true;
     }
 }
 

--- a/ts/model/strand.ts
+++ b/ts/model/strand.ts
@@ -433,9 +433,3 @@ class Generic extends Strand {
     }
 
 }
-
-class PatchyStrand extends Generic{
-    createBasicElement(id?: number) {
-        return new PatchySphere(id, this);
-    };
-}

--- a/ts/model/system.ts
+++ b/ts/model/system.ts
@@ -298,6 +298,7 @@ class System {
 class PatchySystem extends System {
     patchyGeometries: THREE.InstancedBufferGeometry[];
     patchyMeshes: THREE.Mesh[];
+    pickingMeshes: THREE.Mesh[];
     offsets: Float32Array[];
     rotations: Float32Array[];
     colors: Float32Array[];
@@ -427,6 +428,9 @@ class PatchySystem extends System {
     callUpdates(names : string[]) {
         names.forEach((name) => {
             this.patchyMeshes.forEach(mesh=>{
+                mesh.geometry["attributes"][name].needsUpdate = true;
+            });
+            this.pickingMeshes.forEach(mesh=>{
                 mesh.geometry["attributes"][name].needsUpdate = true;
             });
         });

--- a/ts/model/system.ts
+++ b/ts/model/system.ts
@@ -303,8 +303,9 @@ class PatchySystem extends System {
     colors: Float32Array[];
     scalings: Float32Array[];
     visibilities: Float32Array[];
+    labels: Float32Array[];
 
-    particles: PatchySphere[];
+    particles: PatchyParticle[];
     species: {
         type: number,
         patches: any[]
@@ -420,6 +421,7 @@ class PatchySystem extends System {
         this.colors = instanceCounts.map(n=>new Float32Array(n * 3));
         this.scalings = instanceCounts.map(n=>new Float32Array(n * 3));
         this.visibilities = instanceCounts.map(n=>new Float32Array(n * 3));
+        this.labels = instanceCounts.map(n=>new Float32Array(n * 3));
     }
 
     callUpdates(names : string[]) {

--- a/ts/scene/PBC_switchbox.ts
+++ b/ts/scene/PBC_switchbox.ts
@@ -23,6 +23,27 @@ function centerAndPBCBtnClick(elems?: BasicElement[]){
     centerAndPBC(elems);
 }
 
+function shiftWithinBox(v: THREE.Vector3, elems?: BasicElement[], targetBox?: THREE.Vector3) {
+    if (!elems) {
+        elems = Array.from(elements.values());
+    }
+    if (!targetBox) {
+        targetBox = box;
+    }
+    translateElements(new Set(elems), v);
+    bringInBox(elems, getInboxingMode(), targetBox);
+    // Update instances
+    let affectedSystems = new Set<System>();
+    elems.forEach(e=>{
+        if (e.n3) calcsp(e);
+        affectedSystems.add(e.getSystem());
+    });
+    affectedSystems.forEach(s=>s.callUpdates(['instanceOffset']));
+    tmpSystems.forEach(s=>s.callUpdates(['instanceOffset']));
+    if(forceHandler) forceHandler.redraw();
+    render();
+}
+
 /**
  * Center elements in the simulation box and then apply periodic boundary conditions to bring them all in the same box instance.
  * @param elems Optional parameter defining which particles to apply the centering and PBC to.  Defaults to all particles.

--- a/ts/typescript_definitions/index.d.ts
+++ b/ts/typescript_definitions/index.d.ts
@@ -24,6 +24,7 @@ export * from "./three-core";
 
 export * from "./three-canvasrenderer";
 export * from "./three-colladaLoader";
+export * from "./three-convexgeometry";
 export * from "./three-copyshader";
 export * from "./three-css3drenderer";
 export * from "./three-ctmloader";

--- a/ts/typescript_definitions/three-convexgeometry.d.ts
+++ b/ts/typescript_definitions/three-convexgeometry.d.ts
@@ -1,0 +1,5 @@
+import { BufferGeometry, Vector3 } from "./three-core";
+
+export class ConvexGeometry extends BufferGeometry {
+    constructor(points: Vector3[]);
+}

--- a/ts/typescript_definitions/three-convexgeometry.d.ts
+++ b/ts/typescript_definitions/three-convexgeometry.d.ts
@@ -1,5 +1,9 @@
-import { BufferGeometry, Vector3 } from "./three-core";
+import { BufferGeometry, Geometry, Vector3 } from "./three-core";
 
-export class ConvexGeometry extends BufferGeometry {
+export class ConvexGeometry extends Geometry {
     constructor(points: Vector3[]);
+  }
+
+export class ConvexBufferGeometry extends BufferGeometry {
+constructor(points: Vector3[]);
 }


### PR DESCRIPTION
By dropping both `patches.txt` and `particles.txt` you can now visualise patchy particles with patches and their orientations. The current visualisation is not representative of the excluded volume, but I will try to add spheres with attached patches later. A lot of code was needed to get the instancing to work with other objects.