### PR TITLE
Fix for Patch Files with No a1 or a2

### DIFF
--- a/dist/file_handling/file_reading.js
+++ b/dist/file_handling/file_reading.js
@@ -1076,17 +1076,24 @@ function addSystemToScene(system) {
                 s.species[i].patches.forEach(patch => {
                     // Need to invert y and z axis for mysterious reasons
                     const pos = patch.position.clone();
-                    pos.y *= -1;
-                    pos.z *= -1;
-                    let a1 = patch.a1.clone();
-                    a1.y *= -1;
-                    a1.z *= -1;
-                    let a2 = patch.a2.clone();
-                    a2.y *= -1;
-                    a2.z *= -1;
+                    let a1, a2;
                     let aw = patchAlignWidth;
+                    if (('a1' in patch) && ('a2' in patch)){
+                        pos.y *= -1;
+                        pos.z *= -1;
+                        a1 = patch.a1.clone();
+                        a1.y *= -1;
+                        a1.z *= -1;
+                        a2 = patch.a2.clone();
+                        a2.y *= -1;
+                        a2.z *= -1;
+                    }
+                    else {
+                        a1 = new THREE.Vector3();
+                        a2 = new THREE.Vector3();
+                    }
                     // Too many patches.txt files fail to set a1 and a2 correctly.
-                    if (Math.abs(a1.dot(a2)) > 1e-5) {
+                    if (!('a1' in patch) || !('a2' in patch) || Math.abs(a1.dot(a2)) > 1e-5) {
                         console.warn(`The a1 and a2 vectors are incorrectly defined in species ${i}. Using patch position instead`);
                         a1 = pos.clone();
                         a1.normalize();


### PR DESCRIPTION
Extremely minor adjustment to patchy particle file loader. Added conditional so that if a1 and a2 values are missing the loader will calculate them based off patch positions. The code already existed to do this so I just needed to add checks for missing a1 and a2 values.