### PR TITLE
Add feature to search multiple sequences/IDs

### DIFF
--- a/dist/editing/editing.js
+++ b/dist/editing/editing.js
@@ -305,6 +305,10 @@ function findDomainWrapper() {
             const nucleotide = elements.get(parseInt(input));
             if (nucleotide != undefined) {
                 nucleotide.select();
+                // zoom into nucleotide if it is the only input given
+                if (inputs.length == 1) {
+                    api.findElement(nucleotide);
+                }
             }
             return;
         }

--- a/dist/editing/editing.js
+++ b/dist/editing/editing.js
@@ -297,26 +297,29 @@ function reverseComplementWrapper() {
     seqInp.value = seq;
 }
 function findDomainWrapper() {
-    const seq = view.getInputValue("sequence").toUpperCase();
-    //if number is given, finds element with that ID
-    if (!isNaN(parseInt(seq)) && !isNaN(Number(seq))) {
-        const nucleotide = elements.get(Number(seq));
-        if (nucleotide != undefined) {
-            nucleotide.select();
-            api.findElement(nucleotide);
-            systems.forEach(system => { updateView(system); });
+    // create array of comma-separated inputs with no whitespaces
+    const inputs = view.getInputValue("sequence").toUpperCase().replace(/\s/g, "").split(",");
+    inputs.forEach(input => {
+        // select nucleotide if given an ID
+        if (/^[0-9]+$/.test(input)) {
+            const nucleotide = elements.get(parseInt(input));
+            if (nucleotide != undefined) {
+                nucleotide.select();
+            }
+            return;
         }
-        return;
-    }
-    const search_func = system => {
-        system.strands.forEach(strand => {
-            strand.search(seq).forEach(match => {
-                api.selectElements(match, true);
+        // else select sequences
+        const search_func = system => {
+            system.strands.forEach(strand => {
+                strand.search(input).forEach(match => {
+                    api.selectElements(match, true);
+                });
             });
-        });
-    };
-    systems.forEach(search_func);
-    tmpSystems.forEach(search_func);
+        };
+        systems.forEach(search_func);
+        tmpSystems.forEach(search_func);
+    });
+    systems.forEach(system => { updateView(system); });
     render();
 }
 function skipWrapper() {

--- a/ts/editing/editing.ts
+++ b/ts/editing/editing.ts
@@ -342,7 +342,11 @@ function findDomainWrapper() {
             const nucleotide: BasicElement = elements.get(parseInt(input));
             if (nucleotide != undefined) {
                 nucleotide.select();
-            } 
+                // zoom into nucleotide if it is the only input given
+                if (inputs.length == 1) {
+                    api.findElement(nucleotide);
+                } 
+            }
             return;
         }
         // else select sequences

--- a/ts/editing/editing.ts
+++ b/ts/editing/editing.ts
@@ -334,27 +334,30 @@ function reverseComplementWrapper(){
 }
 
 function findDomainWrapper() {
-    const seq: string = view.getInputValue("sequence").toUpperCase();
-    //if number is given, finds element with that ID
-    if (!isNaN(parseInt(seq))) {
-        const nucleotide: BasicElement = elements.get(Number(seq));
-        if (nucleotide != undefined) {
-            nucleotide.select();
-            api.findElement(nucleotide);
-            systems.forEach(system => {updateView(system)});
+    // create array of comma-separated inputs with no whitespaces
+    const inputs: Array<string> = view.getInputValue("sequence").toUpperCase().replace(/\s/g,"").split(",");
+    inputs.forEach(input => {
+        // select nucleotide if given an ID
+        if (/^[0-9]+$/.test(input)) {
+            const nucleotide: BasicElement = elements.get(parseInt(input));
+            if (nucleotide != undefined) {
+                nucleotide.select();
+            } 
+            return;
         }
-        return;
-    }  
-    const search_func = system => {
-        system.strands.forEach(strand => {
-            strand.search(seq).forEach(match => {
-                api.selectElements(match, true);
+        // else select sequences
+        const search_func = system => {
+            system.strands.forEach(strand => {
+                strand.search(input).forEach(match => {
+                    api.selectElements(match, true);
+                });
             });
-        });
-    };
+        };
         systems.forEach(search_func);
         tmpSystems.forEach(search_func);
-        render();
+    });
+    systems.forEach(system => {updateView(system)});
+    render();
 }
 
 function skipWrapper() {


### PR DESCRIPTION
Implemented the feature to search for multiple sequences and IDs at once by separating them with commas. If the only input is an index for a nucleotide, the nucleotide will be focused on.

![image](https://github.com/sulcgroup/oxdna-viewer/assets/117968477/bf2cdf6c-5723-4d85-93be-abcaed122c04)