### PR TITLE
Make enter key another way to call sequence search

### DIFF
--- a/dist/editing/editing.js
+++ b/dist/editing/editing.js
@@ -326,6 +326,13 @@ function findDomainWrapper() {
     systems.forEach(system => { updateView(system); });
     render();
 }
+// enter key functions same as search button
+document.getElementById("sequence").addEventListener('keydown', function (event) {
+    if (event.code === "Enter") {
+        event.preventDefault();
+        findDomainWrapper();
+    }
+});
 function skipWrapper() {
     let e = Array.from(selectedBases);
     ;

--- a/ts/editing/editing.ts
+++ b/ts/editing/editing.ts
@@ -364,6 +364,14 @@ function findDomainWrapper() {
     render();
 }
 
+// enter key functions same as search button
+document.getElementById("sequence").addEventListener('keydown', function(event) {
+  if (event.code === "Enter") {
+    event.preventDefault();
+    findDomainWrapper();
+  }
+});
+
 function skipWrapper() {
     let e: BasicElement[] = Array.from(selectedBases);;
     clearSelection();


### PR DESCRIPTION
Enter key should call the function that selects sequences and nucleotides, like the search button does.