### PR TITLE
Fix broken links in the README and make it possible to change the visibility of arrows and box in an iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A browser-based visualization tool that uses the [Three.js](https://threejs.org/
     + [Edit API](#edit-api)
     + [Observable API](#observable-api)
   * [Rigid Body Simulations](#rigid-body-simulations)
-  * [3D Printing Export](#3d-export)
+  * [3D Export](#3d-export)
   * [Live relaxation of oxDNA configurations](#live-relaxation-of-oxdna-configurations)
   * [Known issues](#known-issues)
   * [Updates and writing your own extensions](#updates-and-writing-your-own-extensions-or-running-oxview-locally)

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ A browser-based visualization tool that uses the [Three.js](https://threejs.org/
     + [Edit API](#edit-api)
     + [Observable API](#observable-api)
   * [Rigid Body Simulations](#rigid-body-simulations)
-  * [3D Printing Export](#3d-printing-export)
+  * [3D Printing Export](#3d-export)
   * [Live relaxation of oxDNA configurations](#live-relaxation-of-oxdna-configurations)
   * [Known issues](#known-issues)
-  * [Updates and writing your own extensions](#updates-and-writing-your-own-extensions-or-running-oxView-locally)
+  * [Updates and writing your own extensions](#updates-and-writing-your-own-extensions-or-running-oxview-locally)
   * [Citation](#citation)
   * [Acknowledgements](#acknowledgements)
 
@@ -201,7 +201,7 @@ If you want to extend the code for your own purposes, you will also need to inst
 
 Alternatively if you are just interested in using oxView locally, do step 1 and proceed straight to step 7. 
 Or check out the release section 
- 
+
 ## Citation
 If you use oxView or our oxDNA analysis package in your research, please cite:  
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![oxdna-viewer interface](img/editing.gif)
 
-A browser-based visualization tool that uses the [Three.js](https://threejs.org/) JavaScript library to create a smooth, seamless oxDNA configuration viewing and editing experience, even for very large configuration files (current record is 1.2 million nucleotides). To begin, either hit the "Try it" link above, or clone the repository and   [follow these steps](#updates-and-writing-your-own-extensions-or-running-oxView-locally). To use, simply drag and drop a topology and configuration/trajectory file pair into the browser window. If you have JSON overlay files, they can be dragged in together with the topology and configuration, or dragged separately later.
+A browser-based visualization tool that uses the [Three.js](https://threejs.org/) JavaScript library to create a smooth, seamless oxDNA configuration viewing and editing experience, even for very large configuration files (current record is 1.2 million nucleotides). To begin, either hit the "Try it" link above, or clone the repository and [follow these steps](#updates-and-writing-your-own-extensions-or-running-oxview-locally). To use, simply drag and drop a topology and configuration/trajectory file pair into the browser window. If you have JSON overlay files, they can be dragged in together with the topology and configuration, or dragged separately later.
 
 ---
 

--- a/ts/file_handling/file_reading.ts
+++ b/ts/file_handling/file_reading.ts
@@ -1450,6 +1450,7 @@ window.addEventListener("message", (event) => {
             let files = event.data.files;
             let ext = event.data.ext;
             let inbox_settings = event.data.inbox_settings;
+            let view_settings = event.data.view_settings;
             if(files.length != ext.length){
                 notify("make sure you pass all files with extenstions");
                 return
@@ -1460,6 +1461,16 @@ window.addEventListener("message", (event) => {
                 view.centeringMode.set(inbox_settings[1]);
                 centerAndPBCBtnClick();
             }
+            // if present, change the preferences for the visiblity of box, arrows and fog
+            if(view_settings) {
+				if("Box" in view_settings) {
+					redrawBox();
+					boxObj.visible = view_settings["Box"];
+				}
+				if("Arrows" in view_settings) {
+					setArrowsVisibility(view_settings["Arrows"]);
+				}
+			}
             //set the names and extensions for every passed file
             for(let i =0; i< files.length; i++){
                 files[i].name = `${i}.${ext[i]}`;

--- a/ts/scene/scene_setup.ts
+++ b/ts/scene/scene_setup.ts
@@ -153,24 +153,20 @@ function redrawBox() {
     boxObj.visible = visible;
 }
 
+function setArrowsVisibility(new_visibility) {
+	for(let name of ["x-axis", "y-axis", "z-axis"]) {
+		let arrowHelper = scene.getObjectByName(name);
+        arrowHelper.visible = new_visibility;
+	}
+}
+
 // Remove coordinate axes from scene.  Hooked to "Display Arrows" checkbox on sidebar.
 function toggleArrows(chkBox: HTMLInputElement) { //make arrows visible or invisible based on checkbox - functionality added to allow for cleaner images
     if (chkBox.checked) {
-        let arrowHelper = scene.getObjectByName("x-axis");
-        arrowHelper.visible = true;
-        arrowHelper = scene.getObjectByName("y-axis");
-        arrowHelper.visible = true;
-        arrowHelper = scene.getObjectByName("z-axis");
-        arrowHelper.visible = true;
-
+        setArrowsVisibility(true);
     }
     else { //if not checked, set all axes to invisible
-        let arrowHelper = scene.getObjectByName("x-axis");
-        arrowHelper.visible = false;
-        arrowHelper = scene.getObjectByName("y-axis");
-        arrowHelper.visible = false;
-        arrowHelper = scene.getObjectByName("z-axis");
-        arrowHelper.visible = false;
+        setArrowsVisibility(false);
     }
     render(); //update scene
 }


### PR DESCRIPTION
This PR fixes 3 broken links I found in the README while reading it and make it possible to change the visibility of arrows and box in an iframe. In particular, the 'iframe_drop' message now supports the following 'view_settings' object that can be used as follows to control the visibility of the box and arrows:

```typescript
[...]
view_settings = {"Box" : false, "Arrows" : true};
[...]
event.target.contentWindow.postMessage({
   message : 'iframe_drop', files: t_blobs, ext: t_ext, 
   inbox_settings: inbox_settings, view_settings: view_settings
   }, 
   "http://localhost:8080/");
```