### PR TITLE
Updated RNA model, fixed helix direction vector

### DIFF
--- a/dist/UI/UI.js
+++ b/dist/UI/UI.js
@@ -994,7 +994,7 @@ class fluxGraph {
                 //    this.chart.toBase64Image();
                 //}
             },
-            responsiveAnimationDuration: 0,
+            responsiveAnimationDuration: 0, // animation duration after a resize
             responsive: true,
             title: {
                 display: true,

--- a/dist/editing/editing.js
+++ b/dist/editing/editing.js
@@ -112,6 +112,7 @@ function extendWrapper(double) {
     //let elems = extendDuplex ? edit.extendDuplex(<Nucleotide>e, seq) : edit.extendStrand(e, seq);
     let elems = [];
     if (extendDuplex) {
+        // When extending, the sequence extends from the selected nucleotide.  It is not necessarily 5-3.
         let c = seq[0];
         seq = seq.slice(1);
         elems = edit.extendStrand(e, c);

--- a/dist/file_handling/order_parameter_selector.js
+++ b/dist/file_handling/order_parameter_selector.js
@@ -58,12 +58,12 @@ let loadHyperSelector = () => {
                 // mode:"dataset", // it is possible to remove the line view from the plot 
                 // intersect:true  // on hover, but i find it to distracting 
             },
-            responsiveAnimationDuration: 0,
+            responsiveAnimationDuration: 0, // animation duration after a resize
             scales: {
                 xAxes: [{ display: true, scaleLabel: { display: true, labelString: 'Time' }, gridLines: { drawOnChartArea: false } }],
                 yAxes: [{ display: true, gridLines: { drawOnChartArea: false } }],
             },
-            spanGaps: true,
+            spanGaps: true, // handle null in the chart data
             annotation: {
                 events: ["click"],
                 annotations: [
@@ -143,7 +143,7 @@ let handleParameterDrop = (files) => {
             else {
                 console.log("adding new axis");
                 myChart.options.scales.yAxes.push({
-                    type: 'linear',
+                    type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
                     display: true,
                     position: 'left',
                     id: `y-axis-id${axis_counter}`,
@@ -159,7 +159,7 @@ let handleParameterDrop = (files) => {
                         labels: labels,
                         datasets: [
                             {
-                                label: parameter_name,
+                                label: parameter_name, //files[0].name.split(".")[0],
                                 data: data,
                                 fill: false,
                                 borderColor: chartColorMap.get(),
@@ -170,7 +170,7 @@ let handleParameterDrop = (files) => {
                 }
                 else {
                     myChart.data.datasets.push({
-                        label: parameter_name,
+                        label: parameter_name, //files[i].name.split(".")[0],
                         data: data,
                         fill: false,
                         borderColor: chartColorMap.get(),

--- a/dist/file_handling/output_file.js
+++ b/dist/file_handling/output_file.js
@@ -128,9 +128,9 @@ function getNewIds(useNew = false) {
     });
     // these subtypes are not implemented in the CG-oxDNA model, just used for a 'relative' subtype that oxDNA will take as input
     let gsSubtypes = {
-        subtypelist: [],
-        masses: [],
-        radii: [],
+        subtypelist: [], // per particle subtype assignment
+        masses: [], //
+        radii: [], //
         subtype: -1
     };
     // Next, generic sphere objects
@@ -477,9 +477,9 @@ function makeUNFOutput(name) {
             let naStrandsSchema = {
                 "id": strand.id,
                 "name": strand.label,
-                "isScaffold": strand.getLength() > 1000 ? true : false,
-                "naType": strand.end5.isDNA() ? "DNA" : "RNA",
-                "color": strand.end5.color ? '#'.concat(strand.end5.color.getHexString()) : '',
+                "isScaffold": strand.getLength() > 1000 ? true : false, //entirely arbitrary, but generally right.
+                "naType": strand.end5.isDNA() ? "DNA" : "RNA", // Nucleotide type is actually pretty poorly defined in oxView, so this is the best I can do
+                "color": strand.end5.color ? '#'.concat(strand.end5.color.getHexString()) : '', // OxView defines colors on a per-nucleotide level while UNF defines it at the strand level.
                 "fivePrimeId": strand.end5.id,
                 "threePrimeId": strand.end3.id,
                 "pdbFileId": 0,
@@ -504,7 +504,7 @@ function makeUNFOutput(name) {
             let aaChainSchema = {
                 "id": strand.id,
                 "chainName": strand.label,
-                "color": strand.end5.color ? '#'.concat(strand.end5.color.getHexString()) : '',
+                "color": strand.end5.color ? '#'.concat(strand.end5.color.getHexString()) : '', // OxView defines colors on a per-nucleotide level while UNF defines it at the strand level.
                 "pdbFileId": 0,
                 "nTerm": strand.end5.id,
                 "cTerm": strand.end3.id,

--- a/dist/file_handling/pdb_worker.js
+++ b/dist/file_handling/pdb_worker.js
@@ -20,48 +20,48 @@ this.onmessage = function (e) {
     postMessage(ret, undefined);
 };
 var backboneColors = [
-    new THREE.Color(0xfdd291),
-    new THREE.Color(0xffb322),
-    new THREE.Color(0x437092),
+    new THREE.Color(0xfdd291), //light yellow
+    new THREE.Color(0xffb322), //goldenrod
+    new THREE.Color(0x437092), //dark blue
     new THREE.Color(0x6ea4cc), //light blue
 ];
 var nucleosideColors = [
-    new THREE.Color(0x4747B8),
-    new THREE.Color(0xFFFF33),
+    new THREE.Color(0x4747B8), //A or K; Royal Blue
+    new THREE.Color(0xFFFF33), //G or C; Medium Yellow
     //C or A
-    new THREE.Color(0x8CFF8C),
+    new THREE.Color(0x8CFF8C), //Medium green
     //T/U or T
-    new THREE.Color(0xFF3333),
+    new THREE.Color(0xFF3333), //Red
     //E
-    new THREE.Color(0x660000),
+    new THREE.Color(0x660000), //Dark Brown
     //S
-    new THREE.Color(0xFF7042),
+    new THREE.Color(0xFF7042), //Medium Orange
     //D
-    new THREE.Color(0xA00042),
+    new THREE.Color(0xA00042), //Dark Rose
     //N
-    new THREE.Color(0xFF7C70),
+    new THREE.Color(0xFF7C70), //Light Salmon
     //Q
-    new THREE.Color(0xFF4C4C),
+    new THREE.Color(0xFF4C4C), //Dark Salmon
     //H
-    new THREE.Color(0x7070FF),
+    new THREE.Color(0x7070FF), //Medium Blue
     //G
-    new THREE.Color(0xEBEBEB),
+    new THREE.Color(0xEBEBEB), // light GREY
     //P
-    new THREE.Color(0x525252),
+    new THREE.Color(0x525252), //Dark Grey
     //R
-    new THREE.Color(0x00007C),
+    new THREE.Color(0x00007C), //Dark Blue
     //V
-    new THREE.Color(0x5E005E),
+    new THREE.Color(0x5E005E), //Dark Purple
     //I
-    new THREE.Color(0x004C00),
+    new THREE.Color(0x004C00), //Dark Green
     //L
-    new THREE.Color(0x455E45),
+    new THREE.Color(0x455E45), //Olive Green
     //M
-    new THREE.Color(0xB8A042),
+    new THREE.Color(0xB8A042), //Light Brown
     //F
-    new THREE.Color(0x534C42),
+    new THREE.Color(0x534C42), //Olive Grey
     //Y
-    new THREE.Color(0x8C704C),
+    new THREE.Color(0x8C704C), //Medium Brown
     //W
     new THREE.Color(0x4F4600), //Olive Brown
 ];

--- a/dist/model/RNA.js
+++ b/dist/model/RNA.js
@@ -45,8 +45,12 @@ class RNANucleotide extends Nucleotide {
         // Current nucleotide information
         const oldA1 = this.getA1();
         const oldA3 = this.getA3();
-        // You can define the helix axis based on a1 and a3.  This is the inverse of how a3 is assigned below.
-        dir = (oldA3.clone().sub(oldA1.clone().multiplyScalar(Math.sin(inclination))).divideScalar(-(Math.cos(inclination) - Math.pow(Math.sin(inclination), 2))));
+        // You can define the helix axis based on a1 and a3.
+        // The helix direction is the inverse of the normal vector a3 ajusted for the inclination.
+        let normA1A3 = oldA1.clone().cross(oldA3); // normal vector to the plane defined by a1 and a3
+        let q_dir = new THREE.Quaternion(); // quaternion to rotate a3 to the correct orientation
+        q_dir.setFromAxisAngle(normA1A3, inclination); // rotate a3 to 
+        let dir = oldA3.clone().applyQuaternion(q_dir).multiplyScalar(-1);
         dir.normalize();
         // Correctly orient the helix for the direction you're going
         if (direction == "n5") {

--- a/dist/scene/mesh_setup.js
+++ b/dist/scene/mesh_setup.js
@@ -38,49 +38,49 @@ function switchMaterial(material) {
 }
 // Default colors for the backbones
 var backboneColors = [
-    new THREE.Color(0xfdd291),
-    new THREE.Color(0xffb322),
-    new THREE.Color(0x437092),
+    new THREE.Color(0xfdd291), //light yellow
+    new THREE.Color(0xffb322), //goldenrod
+    new THREE.Color(0x437092), //dark blue
     new THREE.Color(0x6ea4cc), //light blue
 ];
 // define nucleoside colors
 var nucleosideColors = [
-    new THREE.Color(0x4747B8),
-    new THREE.Color(0xFFFF33),
+    new THREE.Color(0x4747B8), //A or K; Royal Blue
+    new THREE.Color(0xFFFF33), //G or C; Medium Yellow
     //C or A
-    new THREE.Color(0x8CFF8C),
+    new THREE.Color(0x8CFF8C), //Medium green
     //T/U or T
-    new THREE.Color(0xFF3333),
+    new THREE.Color(0xFF3333), //Red
     //E
-    new THREE.Color(0x660000),
+    new THREE.Color(0x660000), //Dark Brown
     //S
-    new THREE.Color(0xFF7042),
+    new THREE.Color(0xFF7042), //Medium Orange
     //D
-    new THREE.Color(0xA00042),
+    new THREE.Color(0xA00042), //Dark Rose
     //N
-    new THREE.Color(0xFF7C70),
+    new THREE.Color(0xFF7C70), //Light Salmon
     //Q
-    new THREE.Color(0xFF4C4C),
+    new THREE.Color(0xFF4C4C), //Dark Salmon
     //H
-    new THREE.Color(0x7070FF),
+    new THREE.Color(0x7070FF), //Medium Blue
     //G
-    new THREE.Color(0xEBEBEB),
+    new THREE.Color(0xEBEBEB), // light GREY
     //P
-    new THREE.Color(0x525252),
+    new THREE.Color(0x525252), //Dark Grey
     //R
-    new THREE.Color(0x00007C),
+    new THREE.Color(0x00007C), //Dark Blue
     //V
-    new THREE.Color(0x5E005E),
+    new THREE.Color(0x5E005E), //Dark Purple
     //I
-    new THREE.Color(0x004C00),
+    new THREE.Color(0x004C00), //Dark Green
     //L
-    new THREE.Color(0x455E45),
+    new THREE.Color(0x455E45), //Olive Green
     //M
-    new THREE.Color(0xB8A042),
+    new THREE.Color(0xB8A042), //Light Brown
     //F
-    new THREE.Color(0x534C42),
+    new THREE.Color(0x534C42), //Olive Grey
     //Y
-    new THREE.Color(0x8C704C),
+    new THREE.Color(0x8C704C), //Medium Brown
     //W
     new THREE.Color(0x4F4600), //Olive Brown
 ];

--- a/ts/model/RNA.ts
+++ b/ts/model/RNA.ts
@@ -55,8 +55,12 @@ class RNANucleotide extends Nucleotide {
         const oldA1 = this.getA1();
         const oldA3 = this.getA3();
 
-        // You can define the helix axis based on a1 and a3.  This is the inverse of how a3 is assigned below.
-        dir = (oldA3.clone().sub(oldA1.clone().multiplyScalar(Math.sin(inclination))).divideScalar(-(Math.cos(inclination) - Math.pow(Math.sin(inclination),2)))); 
+        // You can define the helix axis based on a1 and a3.
+        // The helix direction is the inverse of the normal vector a3 ajusted for the inclination.
+        let normA1A3 = oldA1.clone().cross(oldA3); // normal vector to the plane defined by a1 and a3
+        let q_dir = new THREE.Quaternion(); // quaternion to rotate a3 to the correct orientation
+        q_dir.setFromAxisAngle(normA1A3, inclination); // rotate a3 to 
+        let dir = oldA3.clone().applyQuaternion(q_dir).multiplyScalar(-1);
         dir.normalize();
 
         // Correctly orient the helix for the direction you're going


### PR DESCRIPTION
The extendStrand method in the RNA model calculates the helix axis and generates an RNA helix starting from a nucleotide. Previously, the calculation of the helix axis had a minor inaccuracy, resulting in a noticeable kink when extending the RNA helix. This discrepancy caused the helix axis of the extended part to deviate slightly from the original helix axis.
For instance (see the image), a 100 bp RNA helix was extended twice, making the kink particularly evident in the orthogonal view.
I have refined the calculation of the helix axis based on the nucleotide coordinates. With this update, the extended RNA helix maintains a consistent axis, eliminating the kink. The RNA helix extension now appears smooth.

![comparison](https://github.com/user-attachments/assets/0209fd09-a9bb-403b-bdec-1e952d82893d)
