### PR TITLE
Forceplane vizualisation

### DIFF
--- a/dist/file_handling/aux_readers.js
+++ b/dist/file_handling/aux_readers.js
@@ -99,34 +99,47 @@ const handleCSV = (file) => {
         render();
     });
 };
-//parse a trap file
-function readTrap(trapFile) {
-    trapFile.text().then(text => {
+function readForce(forceFile) {
+    forceFile.text().then(text => {
         //{ can be replaced with \n to make sure no parameter is lost
         while (text.indexOf("{") >= 0)
             text = text.replace("{", "\n");
-        // traps can be split by } because everything between {} is one trap
-        let traps = text.split("}");
+        // forces can be split by } because everything between {} is one force
+        let forces = text.split("}");
         let trap_objs = [];
-        traps.forEach((trap) => {
-            let lines = trap.split('\n');
+        forces.forEach((force) => {
+            let lines = force.split('\n');
             //empty lines and empty traps need not be processed as well as comments
             lines = lines.filter((line) => line !== "" && !line.startsWith("#"));
             if (lines.length == 0)
                 return;
             let trap_obj = {};
             lines.forEach((line) => {
+                // remove comments
                 let com_pos = line.indexOf("#");
                 if (com_pos >= 0)
                     line = line.slice(0, com_pos).trim();
-                //another chance an empty line can be encountered. Remove whitespace
+                // another chance an empty line can be encountered. Remove whitespace
                 if (line.trim().length == 0)
                     return;
-                //split into option name and value
+                // split into option name and value
                 let options = line.split("=");
                 let lft = options[0].trim();
                 let rght = options[1].trim();
-                trap_obj[lft] = Number.isNaN(parseFloat(rght)) ? rght : parseFloat(rght);
+                // Check if the string represents a list of floats (numbers separated by commas)
+                if (rght.includes(',')) {
+                    // Split the string by commas and convert each part to a float
+                    let floatList = rght.split(',').map(Number);
+                    trap_obj[lft] = floatList;
+                }
+                else if (/^-?\d+(\.\d+)?$/.test(rght)) {
+                    // Check if the entire string is a valid number
+                    trap_obj[lft] = parseFloat(rght);
+                }
+                else {
+                    // Otherwise, treat it as a string
+                    trap_obj[lft] = rght;
+                }
             });
             if (Object.keys(trap_obj).length > 0)
                 trap_objs.push(trap_obj);
@@ -146,8 +159,20 @@ function readTrap(trapFile) {
                     skewTrap.update();
                     forces.push(skewTrap);
                     break;
+                case "repulsion_plane":
+                    let repPlane = new RepulsionPlane();
+                    repPlane.setFromParsedJson(f);
+                    repPlane.update();
+                    forces.push(repPlane);
+                    break;
+                case "attraction_plane":
+                    let attrPlane = new AttractionPlane();
+                    attrPlane.setFromParsedJson(f);
+                    attrPlane.update();
+                    forces.push(attrPlane);
+                    break;
                 default:
-                    notify(`External force ${f["type"]} type not supported yet, feel free to implement in aux_readers.ts and force.ts`);
+                    notify(`External force -${f["type"]}- type not supported yet, feel free to implement in aux_readers.ts and force.ts`);
                     break;
             }
         });

--- a/dist/file_handling/file_handling.js
+++ b/dist/file_handling/file_handling.js
@@ -88,7 +88,7 @@ async function handleFiles(files) {
             auxFiles.push(new File2reader(files[i], 'json', readJson));
         }
         else if (ext === "txt" && (fileName.includes("trap") || fileName.includes("force"))) {
-            auxFiles.push(new File2reader(files[i], 'force', readTrap));
+            auxFiles.push(new File2reader(files[i], 'force', readForce));
         }
         else if (ext === "txt" && (fileName.includes("_m"))) {
             auxFiles.push(new File2reader(files[i], 'mass', readMassFile));

--- a/dist/main.js
+++ b/dist/main.js
@@ -122,7 +122,6 @@ var lut, devs;
 const editHistory = new EditHistory(); // Track do/undo
 var tmpSystems = []; // Track memory for newly created systems
 var topologyEdited = false; // to keep track of if the topology was edited at any point.
-
 function resetScene(resetCamera = true) {
     elements.clear();
     while (systems.length > 0) {
@@ -178,7 +177,6 @@ function resetScene(resetCamera = true) {
     if (resetCamera) {
         controls.reset();
     }
-
     render();
 }
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/dist/model/force.js
+++ b/dist/model/force.js
@@ -292,7 +292,7 @@ class ForceHandler {
         this.set(forces);
     }
     set(forces) {
-        this.clear_forces_from_scene();
+        // this.clear_forces_from_scene();
         this.traps = forces.filter(f => this.knownTrapForces.includes(f.type));
         this.draw_traps();
         this.planes = forces.filter(f => this.knownPlaneForces.includes(f.type));
@@ -339,9 +339,7 @@ class ForceHandler {
         //trajReader.previousConfig = api.observable.wrap(trajReader.previousConfig, this.update);    
     }
     draw_planes() {
-        notify("Drawing planes");
         this.planes.forEach(f => {
-            console.log("Drawing plane for force " + f);
             let _extent = 512;
             let _color = this.planeColors[this.planes.indexOf(f) % this.planeColors.length];
             //  draw text on plane

--- a/dist/model/force.js
+++ b/dist/model/force.js
@@ -163,26 +163,148 @@ class SkewTrap extends PairwiseForce {
         ];
     }
 }
+// Forces which can be drawn as a plane
+class PlaneForce extends Force {
+    set(particles, stiff = 0.09, position = 0, dir = new THREE.Vector3(0, 0, 1)) {
+        this.particles = particles;
+        this.stiff = stiff;
+        this.dir = dir;
+        this.position = position;
+        this.update();
+    }
+    setFromParsedJson(parsedjson) {
+        console.log(parsedjson);
+        for (var param in parsedjson) {
+            if (param === 'particle') {
+                const particleData = parsedjson[param];
+                if (Array.isArray(particleData)) {
+                    this.particles = particleData.map(id => elements.get(id)).filter(p => p !== undefined);
+                }
+                else if (particleData === -1) {
+                    this.particles = -1;
+                }
+                else {
+                    const singleParticle = elements.get(particleData);
+                    if (singleParticle === undefined) {
+                        const err = `Particle ${particleData} in parsed force file does not exist.`;
+                        notify(err, "alert");
+                        throw (err);
+                    }
+                    this.particles = [singleParticle];
+                }
+            }
+            else if (param === "dir") {
+                const dirData = parsedjson[param];
+                if (Array.isArray(dirData) && dirData.length === 3 && dirData.every(num => typeof num === 'number')) {
+                    this.dir = new THREE.Vector3(...dirData);
+                }
+                else {
+                    const err = `Invalid dir format: ${dirData}`;
+                    notify(err, "alert");
+                    throw (err);
+                }
+            }
+            else {
+                this[param] = parsedjson[param];
+            }
+        }
+        this.update();
+    }
+    toJSON() {
+        let particleData;
+        particleData = Array.isArray(this.particles) ? this.particles.map(p => p.id) : this.particles;
+        return {
+            type: this.type,
+            particle: particleData,
+            stiff: this.stiff,
+            dir: this.dir,
+            position: this.position
+        };
+    }
+    toString(idMap) {
+        let particleRepresentation;
+        if (Array.isArray(this.particles)) {
+            particleRepresentation = this.particles.map(p => idMap ? idMap.get(p) : p.id).join(", ");
+        }
+        else {
+            particleRepresentation = this.particles.toString();
+        }
+        return (`{
+    type = ${this.type}
+    particle = ${particleRepresentation}
+    stiff = ${this.stiff}
+    dir = ${this.dir}
+    position = ${this.position}
+}`);
+    }
+    description() {
+        if (this.particles === -1) {
+            return "Plane trap pulling particle all particles towards itself";
+        }
+        else {
+            let particleRepresentation;
+            if (Array.isArray(this.particles)) {
+                particleRepresentation = this.particles.map(p => p.id).join(", ");
+            }
+            else {
+                particleRepresentation = this.particles.toString();
+            }
+            return `Plane trap pulling particles ${particleRepresentation} towards itself`;
+        }
+    }
+    update() {
+        // plane position and orientation are persistent, so no need to update
+    }
+}
+class RepulsionPlane extends PlaneForce {
+    type = 'repulsion_plane';
+    particles = -1; // Can be an array of particles or -1 (all)
+    stiff; // stiffness of the harmonic repulsion potential.
+    dir;
+    position;
+}
+class AttractionPlane extends PlaneForce {
+    type = 'attraction_plane';
+    particles = -1; // Can be an array of particles or -1 (all)
+    stiff; // stiffness of the harmonic repulsion potential and strength of the attractive force
+    dir;
+    position;
+}
 class ForceHandler {
-    traps;
     types;
     sceneObjects = [];
+    knownTrapForces = ['mutual_trap', 'skew_trap']; //these are the forces I know how to draw via lines
+    knownPlaneForces = ["repulsion_plane", "attraction_plane"]; //these are the forces I know how to draw via planes
+    traps;
     forceLines = [];
     eqDistLines;
     forceColors = [
         new THREE.Color(0x0000FF),
         new THREE.Color(0xFF0000),
     ];
-    knownForces = ['mutual_trap', 'skew_trap']; //these are the forces I know how to draw
+    planeColors = [
+        new THREE.Color(0x00FF00),
+        new THREE.Color(0xFF00FF),
+    ];
+    planes;
+    forcePlanes = [];
     constructor(forces) {
         this.set(forces);
     }
     set(forces) {
+        this.clear_forces_from_scene();
+        this.traps = forces.filter(f => this.knownTrapForces.includes(f.type));
+        this.draw_traps();
+        this.planes = forces.filter(f => this.knownPlaneForces.includes(f.type));
+        this.draw_planes();
+    }
+    clear_forces_from_scene() {
         // Remove any old geometry (nothing happens if undefined)
         scene.remove(this.eqDistLines);
         this.forceLines.forEach(fl => scene.remove(fl));
-        // We can only draw pairwise traps so far:
-        this.traps = forces.filter(f => this.knownForces.includes(f.type));
+        this.forcePlanes.forEach(fp => scene.remove(fp));
+    }
+    draw_traps() {
         // find out how many different types there are
         this.types = Array.from((new Set(this.traps.map(trap => trap.type))));
         let v1 = [];
@@ -216,7 +338,57 @@ class ForceHandler {
         //trajReader.nextConfig = api.observable.wrap(trajReader.nextConfig, this.update);
         //trajReader.previousConfig = api.observable.wrap(trajReader.previousConfig, this.update);    
     }
+    draw_planes() {
+        notify("Drawing planes");
+        this.planes.forEach(f => {
+            console.log("Drawing plane for force " + f);
+            let _extent = 512;
+            let _color = this.planeColors[this.planes.indexOf(f) % this.planeColors.length];
+            //  draw text on plane
+            let ccanvas = document.createElement('canvas');
+            let context = ccanvas.getContext('2d');
+            ccanvas.width = _extent;
+            ccanvas.height = _extent;
+            context.fillStyle = '#' + _color.getHex().toString(16).padStart(6, '0');
+            context.fillRect(0, 0, ccanvas.width, ccanvas.height);
+            // text on plane
+            context.font = '8px Arial';
+            context.fillStyle = 'black'; // Text color
+            context.textAlign = 'left'; // Align text to the right
+            let _text = f.type + "\nposition: " + f.position + "\ndir: " + f.dir.x + " " + f.dir.y + " " + f.dir.z;
+            // Split the text into lines and draw each line separately
+            let lines = _text.split('\n');
+            for (let i = 0; i < lines.length; i++) {
+                context.fillText(lines[i], ccanvas.width - 70, ccanvas.height - 10 - (lines.length - 1 - i) * 10);
+            }
+            // Create plane from canvas
+            let texture = new THREE.CanvasTexture(ccanvas);
+            let geometry = new THREE.PlaneGeometry(_extent, _extent);
+            let material = new THREE.MeshBasicMaterial({
+                map: texture,
+                side: THREE.DoubleSide,
+                transparent: true, // Enable transparency
+                opacity: 0.5 // Set the desired opacity (0.0 to 1.0)
+            });
+            let plane = new THREE.Mesh(geometry, material);
+            let targetPosition = f.dir.clone().multiplyScalar(f.position);
+            plane.lookAt(targetPosition);
+            plane.position.set(-f.position * f.dir.x, -f.position * f.dir.y, -f.position * f.dir.z);
+            scene.add(plane);
+            this.sceneObjects.push(plane);
+            // this.forcePlanes.push(plane);
+            //~10 nm grid helper
+            // let size2 = 1000/.85;
+            // let divisions2 = 100 ;
+            // let gridHelper2 = new THREE.GridHelper( size2, divisions2 );
+            // scene.add( gridHelper2 )
+        });
+    }
     redraw() {
+        this.redraw_traps();
+        render();
+    }
+    redraw_traps() {
         let v1 = [];
         let v2 = [];
         for (let i = 0; i < this.types.length; i++) {
@@ -237,7 +409,6 @@ class ForceHandler {
         });
         this.eqDistLines.geometry = new THREE.BufferGeometry();
         this.eqDistLines.geometry.addAttribute('position', new THREE.Float32BufferAttribute(v2, 3));
-        render();
     }
 }
 function makeTrapsFromSelection() {

--- a/dist/model/force.js
+++ b/dist/model/force.js
@@ -371,17 +371,11 @@ class ForceHandler {
                 opacity: 0.5 // Set the desired opacity (0.0 to 1.0)
             });
             let plane = new THREE.Mesh(geometry, material);
-            let targetPosition = f.dir.clone().multiplyScalar(f.position);
-            plane.lookAt(targetPosition);
+            plane.lookAt(f.dir.clone());
             plane.position.set(-f.position * f.dir.x, -f.position * f.dir.y, -f.position * f.dir.z);
             scene.add(plane);
             this.sceneObjects.push(plane);
-            // this.forcePlanes.push(plane);
-            //~10 nm grid helper
-            // let size2 = 1000/.85;
-            // let divisions2 = 100 ;
-            // let gridHelper2 = new THREE.GridHelper( size2, divisions2 );
-            // scene.add( gridHelper2 )
+            this.forcePlanes.push(plane);
         });
     }
     redraw() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/chartjs-plugin-annotation": "^0.5.1",
         "@types/jquery": "^3.5.6",
         "@types/moment": "^2.13.0",
+        "@types/node": "^22.7.4",
         "@types/sizzle": "2.3.2",
         "@types/webvr-api": "0.0.36",
         "@zip.js/zip.js": "^2.3.17",
@@ -1001,9 +1002,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -6378,6 +6382,11 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
     "node_modules/unique-filename": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
@@ -7496,9 +7505,12 @@
       }
     },
     "@types/node": {
-      "version": "18.11.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/responselike": {
       "version": "1.0.0",
@@ -11567,6 +11579,11 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "unique-filename": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/chartjs-plugin-annotation": "^0.5.1",
     "@types/jquery": "^3.5.6",
     "@types/moment": "^2.13.0",
+    "@types/node": "^22.7.4",
     "@types/sizzle": "2.3.2",
     "@types/webvr-api": "0.0.36",
     "@zip.js/zip.js": "^2.3.17",

--- a/ts/file_handling/file_handling.ts
+++ b/ts/file_handling/file_handling.ts
@@ -76,7 +76,7 @@ async function handleFiles(files: File[]) {
         // These file types modify an existing system
         else if (ext == 'dat' || ext == 'conf' || ext == 'oxdna') { auxFiles.push(new File2reader(files[i], 'trajectory', readTraj)); }
         else if (ext === "json") { auxFiles.push(new File2reader(files[i], 'json', readJson)); }
-        else if (ext === "txt" && (fileName.includes("trap") || fileName.includes("force") )) { auxFiles.push(new File2reader(files[i], 'force', readTrap)); }
+        else if (ext === "txt" && (fileName.includes("trap") || fileName.includes("force") )) { auxFiles.push(new File2reader(files[i], 'force', readForce)); }
         else if (ext === "txt" && (fileName.includes("_m"))) { auxFiles.push(new File2reader(files[i], 'mass', readMassFile)); }
         else if (ext === "txt" && (fileName.includes("select"))) { auxFiles.push(new File2reader(files[i], 'select', readSelectFile)); }
         else if (ext === "cam") { auxFiles.push(new File2reader(files[i], 'camera', readCamFile)); }

--- a/ts/model/force.ts
+++ b/ts/model/force.ts
@@ -351,7 +351,7 @@ class ForceHandler{
     }
 
     set(forces: Force[]) {
-        this.clear_forces_from_scene();
+        // this.clear_forces_from_scene();
         this.traps = <PairwiseForce[]> forces.filter(f=>this.knownTrapForces.includes(f.type));
         this.draw_traps();
         this.planes = <PlaneForce[]> forces.filter(f=>this.knownPlaneForces.includes(f.type));
@@ -406,9 +406,7 @@ class ForceHandler{
     }
 
     draw_planes() {
-        notify("Drawing planes");
         this.planes.forEach(f => {
-            console.log("Drawing plane for force " + f);
             let _extent: number = 512;
             let _color = this.planeColors[this.planes.indexOf(f) % this.planeColors.length];
 

--- a/ts/model/force.ts
+++ b/ts/model/force.ts
@@ -204,28 +204,169 @@ class SkewTrap extends PairwiseForce {
     }
 }
 
+// Forces which can be drawn as a plane
+abstract class PlaneForce extends Force {
+    abstract particles: BasicElement[] | number;
+    abstract dir: THREE.Vector3;
+    abstract position: number;
+    abstract stiff: number;
+
+
+    set(particles: BasicElement[] | number, stiff=0.09, position=0, dir=new THREE.Vector3(0,0,1)) {
+        this.particles = particles;
+        this.stiff = stiff;
+        this.dir = dir;
+        this.position = position;
+        this.update();
+    }
+
+    setFromParsedJson(parsedjson) {
+        console.log(parsedjson);
+        for (var param in parsedjson) {
+            if (param === 'particle') {
+                const particleData = parsedjson[param];
+                if (Array.isArray(particleData)) {
+                    this.particles = particleData.map(id => elements.get(id)).filter(p => p !== undefined);
+                } else if (particleData === -1) {
+                    this.particles = -1;
+                } else {
+                    const singleParticle = elements.get(particleData);
+                    if (singleParticle === undefined) {
+                        const err = `Particle ${particleData} in parsed force file does not exist.`;
+                        notify(err, "alert");
+                        throw(err);
+                    }
+                    this.particles = [singleParticle];
+                }
+            } else if (param === "dir") {
+                const dirData = parsedjson[param];
+                if (Array.isArray(dirData) && dirData.length === 3 && dirData.every(num => typeof num === 'number')) {
+                    this.dir = new THREE.Vector3(...dirData);
+                } else {
+                    const err = `Invalid dir format: ${dirData}`;
+                    notify(err, "alert");
+                    throw(err);
+                }
+            } else {
+                this[param] = parsedjson[param];
+            }
+        }
+        this.update();
+    }
+
+    toJSON() {
+        let particleData: number | number[];
+        particleData = Array.isArray(this.particles) ? this.particles.map(p => p.id) : this.particles;
+        return {
+            type: this.type,
+            particle: particleData,
+            stiff: this.stiff,
+            dir: this.dir,
+            position: this.position
+        };
+    }
+
+    toString(idMap?: Map<BasicElement, number>): string {
+        let particleRepresentation: string;
+        if (Array.isArray(this.particles)) {
+            particleRepresentation = this.particles.map(p => idMap ? idMap.get(p) : p.id).join(", ");
+        } else {
+            particleRepresentation = this.particles.toString();
+        }
+        return (
+`{
+    type = ${this.type}
+    particle = ${particleRepresentation}
+    stiff = ${this.stiff}
+    dir = ${this.dir}
+    position = ${this.position}
+}`
+        );
+    }
+
+    description(): string {
+        if (this.particles === -1) {
+            return "Plane trap pulling particle all particles towards itself";
+        } else {
+            let particleRepresentation: string;
+            if (Array.isArray(this.particles)) {
+                particleRepresentation = this.particles.map(p => p.id).join(", ");
+            } else {
+                particleRepresentation = this.particles.toString();
+            }
+            return `Plane trap pulling particles ${particleRepresentation} towards itself`;
+        }
+    }
+
+    update() {
+        // plane position and orientation are persistent, so no need to update
+    }
+
+}
+
+
+class RepulsionPlane extends PlaneForce {
+    type = 'repulsion_plane';
+    particles: BasicElement[] | number = -1; // Can be an array of particles or -1 (all)
+    stiff: number; // stiffness of the harmonic repulsion potential.
+    dir: THREE.Vector3;
+    position: number;
+    
+}
+
+class AttractionPlane extends PlaneForce {
+    type = 'attraction_plane';
+    particles: BasicElement[] | number = -1; // Can be an array of particles or -1 (all)
+    stiff: number; // stiffness of the harmonic repulsion potential and strength of the attractive force
+    dir: THREE.Vector3;
+    position: number;
+}
+
+
 class ForceHandler{
-    traps: PairwiseForce[];
     types: string[];
     sceneObjects: THREE.Object3D[] = [];
+    knownTrapForces: string[] = ['mutual_trap', 'skew_trap']; //these are the forces I know how to draw via lines
+    knownPlaneForces: string[] = ["repulsion_plane", "attraction_plane"]; //these are the forces I know how to draw via planes
+
+    
+    traps: PairwiseForce[];
     forceLines: THREE.LineSegments[] = [];
     eqDistLines: THREE.LineSegments;
     forceColors: THREE.Color[] = [ //add more if you implement more forces
         new THREE.Color(0x0000FF),
         new THREE.Color(0xFF0000),
     ];
-    knownForces: string[] = ['mutual_trap', 'skew_trap']; //these are the forces I know how to draw
+    planeColors: THREE.Color[] = [ //add more if you implement more forces
+        new THREE.Color(0x00FF00),
+        new THREE.Color(0xFF00FF),
+    ];
+
+    planes: PlaneForce[];
+    forcePlanes: THREE.Mesh[] = [];
+
 
     constructor(forces :Force[]) {
         this.set(forces);
     }
 
     set(forces: Force[]) {
+        this.clear_forces_from_scene();
+        this.traps = <PairwiseForce[]> forces.filter(f=>this.knownTrapForces.includes(f.type));
+        this.draw_traps();
+        this.planes = <PlaneForce[]> forces.filter(f=>this.knownPlaneForces.includes(f.type));
+        this.draw_planes();
+    }
+
+    clear_forces_from_scene() {
         // Remove any old geometry (nothing happens if undefined)
         scene.remove(this.eqDistLines);
         this.forceLines.forEach(fl => scene.remove(fl));
-        // We can only draw pairwise traps so far:
-        this.traps = <PairwiseForce[]> forces.filter(f=>this.knownForces.includes(f.type));
+        this.forcePlanes.forEach(fp => scene.remove(fp));
+    }
+
+    draw_traps() {
+        
         // find out how many different types there are
         this.types = Array.from((new Set(this.traps.map(trap=>trap.type))));
         let v1 = [];
@@ -264,7 +405,66 @@ class ForceHandler{
         //trajReader.previousConfig = api.observable.wrap(trajReader.previousConfig, this.update);    
     }
 
+    draw_planes() {
+        notify("Drawing planes");
+        this.planes.forEach(f => {
+            console.log("Drawing plane for force " + f);
+            let _extent: number = 512;
+            let _color = this.planeColors[this.planes.indexOf(f) % this.planeColors.length];
+
+            //  draw text on plane
+            let ccanvas = document.createElement('canvas');
+            let context = ccanvas.getContext('2d');
+            ccanvas.width = _extent
+            ccanvas.height = _extent
+            context.fillStyle = '#' + _color.getHex().toString(16).padStart(6, '0');
+            context.fillRect(0, 0, ccanvas.width, ccanvas.height);
+            // text on plane
+            context.font = '8px Arial';
+            context.fillStyle = 'black'; // Text color
+            context.textAlign = 'left'; // Align text to the right
+            let _text = f.type + "\nposition: " + f.position + "\ndir: " + f.dir.x + " " + f.dir.y + " " + f.dir.z; 
+            // Split the text into lines and draw each line separately
+            let lines = _text.split('\n');
+            for (let i = 0; i < lines.length; i++) {
+                context.fillText(lines[i], ccanvas.width - 70, ccanvas.height - 10 - (lines.length - 1 - i) * 10);
+            }           
+
+            // Create plane from canvas
+            let texture = new THREE.CanvasTexture(ccanvas);
+            let geometry = new THREE.PlaneGeometry(_extent, _extent);
+            let material = new THREE.MeshBasicMaterial({
+                map: texture,
+                side: THREE.DoubleSide,
+                transparent: true, // Enable transparency
+                opacity: 0.5 // Set the desired opacity (0.0 to 1.0)
+            });
+            let plane = new THREE.Mesh(geometry, material);
+
+            let targetPosition = f.dir.clone().multiplyScalar(f.position);
+            plane.lookAt(targetPosition);
+            plane.position.set(-f.position * f.dir.x, -f.position * f.dir.y, -f.position * f.dir.z);
+
+
+
+            scene.add(plane);
+            this.sceneObjects.push(plane);
+            // this.forcePlanes.push(plane);
+
+            //~10 nm grid helper
+            // let size2 = 1000/.85;
+            // let divisions2 = 100 ;
+            // let gridHelper2 = new THREE.GridHelper( size2, divisions2 );
+            // scene.add( gridHelper2 )
+        });
+    }
+
     redraw() {
+        this.redraw_traps();
+        render();
+    }
+
+    redraw_traps() {
         let v1 = [];
         let v2 = [];
         for (let i = 0; i < this.types.length; i++) {
@@ -287,7 +487,6 @@ class ForceHandler{
         
         this.eqDistLines.geometry = new THREE.BufferGeometry();
         this.eqDistLines.geometry.addAttribute('position', new THREE.Float32BufferAttribute(v2, 3));
-        render();
     }
 }
 

--- a/ts/model/force.ts
+++ b/ts/model/force.ts
@@ -440,22 +440,13 @@ class ForceHandler{
                 opacity: 0.5 // Set the desired opacity (0.0 to 1.0)
             });
             let plane = new THREE.Mesh(geometry, material);
-
-            let targetPosition = f.dir.clone().multiplyScalar(f.position);
-            plane.lookAt(targetPosition);
+            
+            plane.lookAt(f.dir.clone());
             plane.position.set(-f.position * f.dir.x, -f.position * f.dir.y, -f.position * f.dir.z);
-
-
 
             scene.add(plane);
             this.sceneObjects.push(plane);
-            // this.forcePlanes.push(plane);
-
-            //~10 nm grid helper
-            // let size2 = 1000/.85;
-            // let divisions2 = 100 ;
-            // let gridHelper2 = new THREE.GridHelper( size2, divisions2 );
-            // scene.add( gridHelper2 )
+            this.forcePlanes.push(plane);
         });
     }
 


### PR DESCRIPTION
adds parsing for RepulsionPlane and AttractionPlane forces to Force module
Force planes are drawn using a Mesh with a Canvas to display its type and properties.

further notes:
* the size of the plane-meshes is hard-coded to 512
* planes are centered around the origin which looks a bit off when the PBC box is shown
-> both cases would require availability of the box-dimensions in the force module.  