### PR TITLE
Force update

### DIFF
--- a/dist/UI/UI.js
+++ b/dist/UI/UI.js
@@ -52,6 +52,9 @@ function createTable(data, header, tableName) {
 }
 function listForces() {
     let forceDOM = document.getElementById("forces");
+    if (!forceDOM) {
+        return;
+    }
     forceDOM.innerHTML = "";
     forceHandler.forceTable = forceHandler.forces.map(force => [force.description(), force.type]);
     forceDOM.appendChild(createTable(forceHandler.forceTable, ['Description', 'Type'], 'forcesTable'));
@@ -59,16 +62,18 @@ function listForces() {
 function deleteSelectedForces() {
     // Remove all forces selected in the force window
     var table = $('#forcesTable').data('table');
-    let removeIndices = table.getSelectedItems().map(s => forceHandler.forceTable.indexOf(s));
+    const selected = table.getSelectedItems();
+    let removeIndices = selected.map(s => selected.indexOf(s));
+    removeIndices.sort((a, b) => { b - a; });
+    removeIndices.reverse();
     // consider changing to https://stackoverflow.com/a/35116966/9738112 so it can be in-place
     // Remove force from both the list of forces and from the table
     forceHandler.forceTable = forceHandler.forceTable.filter((f, i) => !removeIndices.includes(i));
-    removeIndices.forEach(i => {
-        forceHandler.forces.splice(i, 1);
-    });
-    listForces();
-    forceHandler.clearForcesFromScene();
-    forceHandler.drawTraps();
+    forceHandler.removeById(removeIndices);
+}
+function deleteForcesFromBases() {
+    const victims = Array.from(selectedBases);
+    forceHandler.removeByElement(victims, false);
 }
 function drawSystemHierarchy() {
     let checkboxhtml = (label) => `<input onchange="render()" data-role="checkbox" data-caption="${label}">`;

--- a/dist/UI/keybindings.js
+++ b/dist/UI/keybindings.js
@@ -61,6 +61,7 @@ canvas.addEventListener("keydown", event => {
         // Redo: ctrl-shift-z, ctrl-y, cmd-shift-z, cmd-y
         case 'z':
             if (event.ctrlKey || event.metaKey) {
+                event.preventDefault();
                 if (event.shiftKey) {
                     editHistory.redo();
                 }

--- a/dist/api/editing_api.js
+++ b/dist/api/editing_api.js
@@ -224,6 +224,8 @@ var edit;
             if (n5) {
                 strand5 = splitStrand(n5);
             }
+            // Remove associated forces
+            forceHandler.removeByElement(victims, true);
             // Remove pairing
             if (e.isPaired()) {
                 if (e.pair.pair === e) {

--- a/dist/editing/doUndo.js
+++ b/dist/editing/doUndo.js
@@ -99,7 +99,20 @@ class RevertableDeletion extends RevertableEdit {
     victims;
     constructor(victims) {
         const saved = victims.map(e => new InstanceCopy(e));
-        let undo = function () { this.victims = edit.addElements(saved); };
+        const savedForces = forceHandler.getByElement(victims).slice();
+        let undo = function () {
+            // Add elements back to the scene. This creates new elements in a tmpSys.
+            this.victims = edit.addElements(saved);
+            // Map the saved forces onto the newly-created elements.
+            savedForces.forEach(f => {
+                f.particle = this.victims[saved.findIndex(e => e.id == f.particle.id)];
+                if (saved.map(ic => ic.id).includes(f.ref_particle.id)) {
+                    f.ref_particle = this.victims[saved.findIndex(e => e.id == f.ref_particle.id)];
+                }
+            });
+            console.log(savedForces);
+            forceHandler.set(savedForces);
+        };
         let redo = function () { edit.deleteElements(this.victims); };
         super(undo, redo);
         this.victims = victims;

--- a/dist/model/force.js
+++ b/dist/model/force.js
@@ -270,7 +270,7 @@ class AttractionPlane extends PlaneForce {
     position;
 }
 class ForceHandler {
-    types;
+    types = [];
     knownTrapForces = ['mutual_trap', 'skew_trap']; //these are the forces I know how to draw via lines
     knownPlaneForces = ["repulsion_plane", "attraction_plane"]; //these are the forces I know how to draw via planes
     forceColors = [
@@ -379,6 +379,9 @@ class ForceHandler {
         });
     }
     redrawTraps() {
+        if (this.forces.length == 0) {
+            return;
+        }
         let v1 = [];
         let v2 = [];
         for (let i = 0; i < this.types.length; i++) {

--- a/ts/UI/UI.ts
+++ b/ts/UI/UI.ts
@@ -59,6 +59,7 @@ function createTable(data:string[][], header: string[], tableName:string) {
 
 function listForces() {
     let forceDOM = document.getElementById("forces");
+    if (!forceDOM) { return }
     forceDOM.innerHTML = "";
     forceHandler.forceTable = forceHandler.forces.map(force=>[force.description(), force.type]);
     forceDOM.appendChild(createTable(forceHandler.forceTable, ['Description', 'Type'], 'forcesTable'));
@@ -67,20 +68,21 @@ function listForces() {
 function deleteSelectedForces() {
     // Remove all forces selected in the force window
     var table = $('#forcesTable').data('table');
-    let removeIndices = table.getSelectedItems().map(s=>forceHandler.forceTable.indexOf(s));
+    const selected = table.getSelectedItems()
+    let removeIndices = selected.map(s=>selected.indexOf(s));
+    removeIndices.sort((a, b) => {b-a})
+    removeIndices.reverse()
 
     // consider changing to https://stackoverflow.com/a/35116966/9738112 so it can be in-place
     // Remove force from both the list of forces and from the table
     forceHandler.forceTable = forceHandler.forceTable.filter((f,i)=>!removeIndices.includes(i));
-    removeIndices.forEach(i => {
-        forceHandler.forces.splice(i, 1)
-    });
-    
-    listForces();
-    forceHandler.clearForcesFromScene()
-    forceHandler.drawTraps()
+    forceHandler.removeById(removeIndices);
 }
 
+function deleteForcesFromBases() {
+    const victims = Array.from(selectedBases);
+    forceHandler.removeByElement(victims, false);
+}
 
 function drawSystemHierarchy() {
     let checkboxhtml = (label)=> `<input onchange="render()" data-role="checkbox" data-caption="${label}">`;

--- a/ts/UI/keybindings.ts
+++ b/ts/UI/keybindings.ts
@@ -47,6 +47,7 @@ canvas.addEventListener("keydown", event =>{
         // Redo: ctrl-shift-z, ctrl-y, cmd-shift-z, cmd-y
         case 'z':
             if (event.ctrlKey || event.metaKey) {
+                event.preventDefault()
                 if (event.shiftKey) {editHistory.redo();}
                 else {editHistory.undo();}
             } else {

--- a/ts/api/editing_api.ts
+++ b/ts/api/editing_api.ts
@@ -269,6 +269,9 @@ module edit{
                 strand5 = splitStrand(n5);
             }
 
+            // Remove associated forces
+            forceHandler.removeByElement(victims, true);
+
             // Remove pairing
             if(e.isPaired()) {
                 if ((e as Nucleotide).pair.pair === e) {

--- a/ts/model/force.ts
+++ b/ts/model/force.ts
@@ -322,7 +322,7 @@ class AttractionPlane extends PlaneForce {
 }
 
 class ForceHandler{
-    types: string[];
+    types: string[] = [];
     knownTrapForces: string[] = ['mutual_trap', 'skew_trap']; //these are the forces I know how to draw via lines
     knownPlaneForces: string[] = ["repulsion_plane", "attraction_plane"]; //these are the forces I know how to draw via planes
     forceColors: THREE.Color[] = [ //add more if you implement more forces
@@ -450,6 +450,7 @@ class ForceHandler{
     }
 
     redrawTraps() {
+        if (this.forces.length == 0) { return }
         let v1 = [];
         let v2 = [];
         for (let i = 0; i < this.types.length; i++) {

--- a/ts/model/force.ts
+++ b/ts/model/force.ts
@@ -18,6 +18,14 @@ abstract class PairwiseForce extends Force {
     abstract ref_particle: BasicElement;
     abstract force: THREE.Vector3[];
     abstract eqDists: THREE.Vector3[];
+
+    equals(compareForce:PairwiseForce) {
+        if (!(compareForce instanceof PairwiseForce) ) { return false }
+        return(
+            this.particle === compareForce.particle &&
+            this.ref_particle === compareForce.ref_particle
+        )
+    }
 }
 
 class MutualTrap extends PairwiseForce {
@@ -39,6 +47,17 @@ class MutualTrap extends PairwiseForce {
         this.r0 = r0;
         this.PBC = PBC;
         this.update()
+    }
+
+    equals(compareForce: MutualTrap): boolean {
+        if (!(compareForce instanceof MutualTrap) ) { return false }
+        return(
+            this.particle === compareForce.particle &&
+            this.ref_particle === compareForce.ref_particle &&
+            this.stiff === compareForce.stiff &&
+            this.r0 === compareForce.r0 &&
+            this.PBC === compareForce.PBC
+        )
     }
 
     setFromParsedJson(parsedjson) {
@@ -136,6 +155,18 @@ class SkewTrap extends PairwiseForce {
         this.update()
     }
 
+    equals(compareForce: SkewTrap): boolean {
+        if (!(compareForce instanceof SkewTrap) ) { return false }
+        return(
+            this.particle === compareForce.particle &&
+            this.ref_particle === compareForce.ref_particle &&
+            this.stdev === compareForce.stdev &&
+            this.shape === compareForce.shape &&
+            this.r0 === compareForce.r0 &&
+            this.PBC === compareForce.PBC
+        )
+    }
+
     setFromParsedJson(parsedjson) {
         for (var param in parsedjson) {
             if (['particle', 'ref_particle'].includes(param)) {
@@ -211,6 +242,15 @@ abstract class PlaneForce extends Force {
     abstract position: number;
     abstract stiff: number;
 
+    equals(compareForce:PairwiseForce) {
+        if (!(compareForce instanceof PlaneForce) ) { return false }
+        return(
+            this.particles === compareForce.particles &&
+            this.dir === compareForce.dir &&
+            this.position === compareForce.position &&
+            this.stiff === compareForce.stiff
+        )
+    }
 
     set(particles: BasicElement[] | number, stiff=0.09, position=0, dir=new THREE.Vector3(0,0,1)) {
         this.particles = particles;
@@ -303,7 +343,6 @@ abstract class PlaneForce extends Force {
 
 }
 
-
 class RepulsionPlane extends PlaneForce {
     type = 'repulsion_plane';
     particles: BasicElement[] | number = -1; // Can be an array of particles or -1 (all)
@@ -347,8 +386,44 @@ class ForceHandler{
 
     set(forces: Force[]) {
         this.forces.push(...forces)
-        this.drawTraps();
-        this.drawPlanes();
+        try {
+            if (this.sceneObjects.length > 0) { this.clearForcesFromScene() }
+            this.drawTraps();
+            this.drawPlanes();
+        }
+        catch (exceptionVar) {
+            forces.forEach(_ => this.forces.pop())
+            notify("Adding forces failed! See console for more information.", "alert")
+            console.error(exceptionVar)
+        }
+    }
+
+    removeByElement(elems: BasicElement[], removePair:boolean=false) {
+        // Get traps which contain the element
+        const pairwiseForces = this.getTraps()
+        let toRemove:Set<Force>
+        if (removePair){ toRemove = new Set(pairwiseForces.filter(f => elems.includes(f.particle) || elems.includes(f.ref_particle))) }
+        else {toRemove = new Set(pairwiseForces.filter(f => elems.includes(f.particle)))}
+        if (toRemove.size == 0) { return }
+
+        // Remove the offending traps
+        this.forces = this.forces.filter(f => !toRemove.has(f))
+        listForces()
+        this.clearForcesFromScene()
+        if (this.forces.length > 0) { this.drawTraps() }
+    }
+
+    removeById(ids: number[]){
+        ids.forEach(i => {
+            this.forces.splice(i, 1)
+        });
+        listForces()
+        this.clearForcesFromScene()
+        if (this.forces.length > 0) { this.drawTraps() }
+    }
+
+    getByElement(elems: BasicElement[]) {
+        return this.getTraps().filter(f => elems.includes(f.particle))
     }
 
     getTraps() {
@@ -399,6 +474,7 @@ class ForceHandler{
         this.eqDistLines = new THREE.LineSegments(eqDistGeom, materials[0]);
         scene.add(this.eqDistLines);
         this.sceneObjects.push(this.eqDistLines);
+        render();
 
         //possibly a better way to fire update
         //trajReader.nextConfig = api.observable.wrap(trajReader.nextConfig, this.update);
@@ -451,8 +527,8 @@ class ForceHandler{
 
     redrawTraps() {
         if (this.forces.length == 0) { return }
-        let v1 = [];
-        let v2 = [];
+        let v1:number[][] = [];
+        let v2:number[] = [];
         for (let i = 0; i < this.types.length; i++) {
             v1.push([]);
         }
@@ -466,13 +542,16 @@ class ForceHandler{
             v2.push(f.eqDists[1].x,f.eqDists[1].y,f.eqDists[1].z);
         });
         this.types.forEach((t, i) => {
-            this.forceLines[i].geometry = new THREE.BufferGeometry();
-            let a = this.forceLines[i].geometry as THREE.BufferGeometry;
-            a.addAttribute('position', new THREE.Float32BufferAttribute(v1[i], 3));
+            for (let j = 0; j < v1[i].length; j++) {
+                this.forceLines[i].geometry["attributes"]["position"].array[j] = v1[i][j]
+            }
+            this.forceLines[i].geometry["attributes"]['position'].needsUpdate = true;
         });
         
-        this.eqDistLines.geometry = new THREE.BufferGeometry();
-        this.eqDistLines.geometry.addAttribute('position', new THREE.Float32BufferAttribute(v2, 3));
+        for (let i = 0; i < v2.length; i++) {
+            this.eqDistLines.geometry["attributes"]['position'].array[i] = v2[i]
+        }
+        this.eqDistLines.geometry["attributes"]['position'].needsUpdate = true;
 
         render()
     }
@@ -506,23 +585,23 @@ function makeTrapsFromSelection() {
 
 function makeTrapsFromPairs() {
     let stiffness = parseFloat((document.getElementById("txtForceValue") as HTMLInputElement).value);
-    let nopairs = true;
-    const forces: PairwiseForce[] = []
-    elements.forEach(e=>{
-        // If element is paired, add a trap
-        if (e.isPaired()) {
-            let trap = new MutualTrap();
-            trap.set(e, (e as Nucleotide).pair, stiffness);
-            forces.push(trap);
-            nopairs = false;
-        }
-    });
+    let nopairs = !systems.every(sys => sys.checkedForBasepairs);
     if (nopairs) {
         ask("No basepair info found", "Do you want to run an automatic basepair search?",
-        ()=>{view.longCalculation(findBasepairs, view.basepairMessage,()=>{
-            makeTrapsFromPairs(); listForces(); // recall this as we now have pairs
-        })})
+        ()=>{view.longCalculation(findBasepairs, view.basepairMessage, makeTrapsFromPairs)})
     }
+
+    const forces: PairwiseForce[] = []
+    elements.forEach(e=>{
+        // If element is paired and the trap doesn't already exist, add a trap
+        if (e.isPaired()) {
+            const currForces = forceHandler.getByElement([e]);
+            let trap = new MutualTrap();
+            trap.set(e, (e as Nucleotide).pair, stiffness);
+            const alreadyExists = currForces.filter(f => f.equals(trap));
+            if (alreadyExists.length === 0) { forces.push(trap); }
+        }
+    });
     forceHandler.set(forces);
-    if(forceHandler.forces.length > 0) forceHandler.redrawTraps();
+    listForces()
 }

--- a/windows/forcesWindow.html
+++ b/windows/forcesWindow.html
@@ -8,6 +8,9 @@
     </button>
 
     <br>
+    <button onclick="deleteForcesFromBases();" class="button outline secondary delete"
+    title="Delete forces from selected bases">Delete from selected bases
+    </button>
     <button onclick="deleteSelectedForces();" class="button outline secondary delete"
     title="Delete all forces selected below">Delete selected
     </button>


### PR DESCRIPTION
Made the following changes:
- Simplified the force handling system
- Created methods to delete forces by element and by ID
- Forces now automatically delete when their nucleotide is deleted
- The forces are re-created on undo
- Fixed bug where force lines would be left behind during oxServe
- Fixed bug where weird things happened if the same force was created twice
- Fixed bug where oxServe would crash if nucleotides with forces on them had been deleted