### PR TITLE
Inlcusion of cylinder and line rendering options for 6-value-long overlay json data

### DIFF
--- a/dist/UI/UI.js
+++ b/dist/UI/UI.js
@@ -1006,7 +1006,7 @@ class fluxGraph {
                 //    this.chart.toBase64Image();
                 //}
             },
-            responsiveAnimationDuration: 0,
+            responsiveAnimationDuration: 0, // animation duration after a resize
             responsive: true,
             title: {
                 display: true,

--- a/dist/file_handling/aux_readers.js
+++ b/dist/file_handling/aux_readers.js
@@ -227,7 +227,7 @@ function parseJson(json, system) {
                     const length = direction.length();
                     // midpoint for cylinder position
                     const midpoint = new THREE.Vector3().addVectors(pos1, pos2).multiplyScalar(0.5);
-                    const geometry = new THREE.CylinderGeometry(radius, radius, length);
+                    const geometry = new THREE.CylinderGeometry(radius, radius, length, 64);
                     const material = new THREE.MeshStandardMaterial({ color: 0xff0000 }); // red
                     const cylinder = new THREE.Mesh(geometry, material);
                     // align cylinder along direction vector (rotate the cylinder so that its y-axis points from pos1 to pos2)

--- a/dist/file_handling/aux_readers.js
+++ b/dist/file_handling/aux_readers.js
@@ -215,13 +215,52 @@ function parseJson(json, system) {
                 }
             }
         }
-        else if (data[key][0].length == 6) { //draw arbitrary arrows on the scene
-            for (let entry of data[key]) {
-                const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
-                const vec = new THREE.Vector3(entry[3], entry[4], entry[5]);
-                vec.normalize();
-                const arrowHelper = new THREE.ArrowHelper(vec, pos, 5 * vec.length(), 0x00000);
-                scene.add(arrowHelper);
+        else if (data[key][0].length == 6) { // if each entry is 6 elements long
+            const hasCylinder = key.toLowerCase().includes("cylinder"); // if the key of the dictionary includes the substring "cylinder"
+            const hasLine = key.toLowerCase().includes("line"); // if the key of the dictionary includes the substring "line"
+            if (hasCylinder) { // Draw cyclinders. The first three and the last three values in each entry are the coordinates of the start- and end-points of the axis.
+                for (let entry of data[key]) {
+                    const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    const radius = 0.8;
+                    const direction = new THREE.Vector3().subVectors(pos2, pos1);
+                    const length = direction.length();
+                    // midpoint for cylinder position
+                    const midpoint = new THREE.Vector3().addVectors(pos1, pos2).multiplyScalar(0.5);
+                    const geometry = new THREE.CylinderGeometry(radius, radius, length);
+                    const material = new THREE.MeshStandardMaterial({ color: 0xff0000 }); // red
+                    const cylinder = new THREE.Mesh(geometry, material);
+                    // align cylinder along direction vector (rotate the cylinder so that its y-axis points from pos1 to pos2)
+                    cylinder.position.copy(midpoint);
+                    cylinder.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), // cylinder default points up along Y
+                    direction.clone().normalize());
+                    scene.add(cylinder);
+                    // remove nucleotide and connector for better visualisation
+                    view.setPropertyInScene('nucleoside', system, false);
+                    view.setPropertyInScene('connector', system, false);
+                }
+            }
+            else if (hasLine) { // Draw lines. The first three and the last three values of each entry are the coordinates of the start- and end-points of the line.
+                for (let entry of data[key]) {
+                    const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    const geometry = new THREE.BufferGeometry().setFromPoints([pos1, pos2]);
+                    const material = new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 0.9 });
+                    const line = new THREE.Line(geometry, material); //a red line that starts at pos1 and ends at pos2
+                    scene.add(line);
+                    // remove nucleotide and connector for better visualisation
+                    view.setPropertyInScene('nucleoside', system, false);
+                    view.setPropertyInScene('connector', system, false);
+                }
+            }
+            else { //draw arbitrary arrows on the scene. First three values of each entry are the coordinates for the starting point, the last three make up the vector.
+                for (let entry of data[key]) {
+                    const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const vec = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    vec.normalize();
+                    const arrowHelper = new THREE.ArrowHelper(vec, pos, 5 * vec.length(), 0x00000);
+                    scene.add(arrowHelper);
+                }
             }
         }
         else { //if json and dat files do not match, display error message and set filesLen to 2 (not necessary)

--- a/dist/file_handling/aux_readers.js
+++ b/dist/file_handling/aux_readers.js
@@ -1,176 +1,157 @@
 /// <reference path="../typescript_definitions/index.d.ts" />
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////               Read a file, modify the scene                ////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-
-function readTraj(trajFile:File, system:System):Promise<string> {
+function readTraj(trajFile, system) {
     system.reader = new TrajectoryReader(trajFile, system);
-    return system.reader.lookupReader.promise
+    return system.reader.lookupReader.promise;
 }
-
-function readJson(jsonFile:File, system:System){ // this still doesn't work for some reason.  It might be a bigger problem tho.
-    return parseFileWith(jsonFile, parseJson, [system])
+function readJson(jsonFile, system) {
+    return parseFileWith(jsonFile, parseJson, [system]);
 }
-
-function readParFile(parFile:File, system:System) {
-    return parseFileWith(parFile, parsePar, [system])
+function readParFile(parFile, system) {
+    return parseFileWith(parFile, parsePar, [system]);
 }
-
 // Nicer lower and upper bound 
 function roundRange(arr) {
-  let min = arr[0], max = arr[0];
-  for(let i = 0; i < arr.length; i++)
-  {
-      if(min > arr[i]) min = arr[i];
-      if(max < arr[i]) max = arr[i];
-  }
-  
-  const roundedMin = Math.floor(min) + (min % 1 >= 0.5 ? 0.5 : 0);
-  const roundedMax = Math.ceil(max) - (max % 1 > 0 && max % 1 <= 0.5 ? 0.5 : 0);
-
-  return [roundedMin, roundedMax];
+    let min = arr[0], max = arr[0];
+    for (let i = 0; i < arr.length; i++) {
+        if (min > arr[i])
+            min = arr[i];
+        if (max < arr[i])
+            max = arr[i];
+    }
+    const roundedMin = Math.floor(min) + (min % 1 >= 0.5 ? 0.5 : 0);
+    const roundedMax = Math.ceil(max) - (max % 1 > 0 && max % 1 <= 0.5 ? 0.5 : 0);
+    return [roundedMin, roundedMax];
 }
-
 // Creates color overlays
 function makeLut(data, key, system) {
-
     let arr = data[key];
     let [min, max] = roundRange(arr);
-   
     // we have no Lut 
-    if (lut == undefined){
-        
+    if (lut == undefined) {
         lut = new THREE.Lut(defaultColormap, 500);
         lut.setMax(max);
-        lut.setMin(min); 
+        lut.setMin(min);
     }
-
     // we need update 
-    if (max > lut.maxV){
+    if (max > lut.maxV) {
         lut.setMax(max);
         api.removeColorbar();
     }
-    if (min < lut.minV){
+    if (min < lut.minV) {
         lut.setMin(min);
         api.removeColorbar();
     }
-
-
     lut.setLegendOn({ 'layout': 'horizontal', 'position': { 'x': 0, 'y': 0, 'z': 0 }, 'dimensions': { 'width': 2, 'height': 12 } }); //create legend
     lut.setLegendLabels({ 'title': key, 'ticks': 5 }); //set up legend format 
 }
-
 // export the current camera position
-const exportCam = ()=>{
+const exportCam = () => {
     const cam = {
         position: camera.position,
         rotation: camera.rotation,
         up: camera.up,
         target: controls.target,
-    }
+    };
     const camJSON = JSON.stringify(cam);
     makeTextFile("camera.cam", camJSON);
-}
+};
 // Read a camera export file
-const readCamFile = (file:File)=>{
-    file.text().then(txt=>{
+const readCamFile = (file) => {
+    file.text().then(txt => {
         const cam = JSON.parse(txt);
-        camera.position.set(cam.position.x,cam.position.y,cam.position.z);
-        camera.rotation.set(cam.rotation.x,cam.rotation.y,cam.rotation.z);
-        camera.up.set(cam.up.x,cam.up.y,cam.up.z);
-        controls.target.set(cam.target.x,cam.target.y,cam.target.z);
-    })
-}
-
+        camera.position.set(cam.position.x, cam.position.y, cam.position.z);
+        camera.rotation.set(cam.rotation.x, cam.rotation.y, cam.rotation.z);
+        camera.up.set(cam.up.x, cam.up.y, cam.up.z);
+        controls.target.set(cam.target.x, cam.target.y, cam.target.z);
+    });
+};
 // Highlight sequences found in cadnano or sequence csv
-const handleCSV = (file:File)=>{
+const handleCSV = (file) => {
     // highlight all the sequences complying with the cadnano file
     // or a line by line sequence file 
-    const search_func = (system,seq) => {
+    const search_func = (system, seq) => {
         system.strands.forEach(strand => {
             strand.search(seq).forEach(match => {
                 api.selectElements(match, true);
             });
         });
     };
-
-    const cadnano_line_to_seq = (line)=> line.split(",")[2].replaceAll("?","N").toUpperCase().trim();
-    const reg_line = (line)=> line.replaceAll("?","N").toUpperCase().trim();
-
+    const cadnano_line_to_seq = (line) => line.split(",")[2].replaceAll("?", "N").toUpperCase().trim();
+    const reg_line = (line) => line.replaceAll("?", "N").toUpperCase().trim();
     //read in a cadnano csv sequence file and highlight them in the scene
-    file.text().then(txt=>{
+    file.text().then(txt => {
         let lines = txt.split("\n");
         let len = lines.length;
         let start_id = 0;
-
         //we handle bothe cadnano and just regular lists
         let processor = reg_line;
-        if (lines[0].startsWith("Start,End,Sequence,Length,Color")){
-            start_id=1;
-            processor= cadnano_line_to_seq;
+        if (lines[0].startsWith("Start,End,Sequence,Length,Color")) {
+            start_id = 1;
+            processor = cadnano_line_to_seq;
         }
-        for(let i=start_id; i<len;i++){
-            if(lines[i]){
-            let seq = processor(lines[i]);
-            console.log(seq)
-            systems.forEach(sys => search_func(sys,seq));
-            tmpSystems.forEach(sys => search_func(sys,seq));
+        for (let i = start_id; i < len; i++) {
+            if (lines[i]) {
+                let seq = processor(lines[i]);
+                console.log(seq);
+                systems.forEach(sys => search_func(sys, seq));
+                tmpSystems.forEach(sys => search_func(sys, seq));
             }
         }
         render();
-            
     });
-}
-
+};
 function readForce(forceFile) {
-    forceFile.text().then(text=>{
+    forceFile.text().then(text => {
         //{ can be replaced with \n to make sure no parameter is lost
-        while(text.indexOf("{")>=0)
-            text = text.replace("{","\n");
+        while (text.indexOf("{") >= 0)
+            text = text.replace("{", "\n");
         // forces can be split by } because everything between {} is one force
         let forceTxt = text.split("}");
-
         let trap_objs = [];
-        forceTxt.forEach((force) =>{
+        forceTxt.forEach((force) => {
             let lines = force.split('\n');
-                //empty lines and empty traps need not be processed as well as comments
-            lines = lines.filter((line)=> line !== "" && !line.startsWith("#"));
-            if(lines.length == 0) return;
-
+            //empty lines and empty traps need not be processed as well as comments
+            lines = lines.filter((line) => line !== "" && !line.startsWith("#"));
+            if (lines.length == 0)
+                return;
             let trap_obj = {};
-            lines.forEach((line)  =>{
+            lines.forEach((line) => {
                 // remove comments
                 let com_pos = line.indexOf("#");
-                if (com_pos >= 0) line =  line.slice(0, com_pos).trim();
+                if (com_pos >= 0)
+                    line = line.slice(0, com_pos).trim();
                 // another chance an empty line can be encountered. Remove whitespace
-                if(line.trim().length == 0) return;
+                if (line.trim().length == 0)
+                    return;
                 // split into option name and value
                 let options = line.split("=");
                 let lft = options[0].trim();
                 let rght = options[1].trim();
-
                 // Check if the string represents a list of floats (numbers separated by commas)
                 if (rght.includes(',')) {
                     // Split the string by commas and convert each part to a float
                     let floatList = rght.split(',').map(Number);
                     trap_obj[lft] = floatList;
-                } else if (/^-?\d+(\.\d+)?$/.test(rght)) {
+                }
+                else if (/^-?\d+(\.\d+)?$/.test(rght)) {
                     // Check if the entire string is a valid number
                     trap_obj[lft] = parseFloat(rght);
-                } else {
+                }
+                else {
                     // Otherwise, treat it as a string
                     trap_obj[lft] = rght;
                 }
             });
-            if(Object.keys(trap_obj).length > 0)
+            if (Object.keys(trap_obj).length > 0)
                 trap_objs.push(trap_obj);
         });
-
-        const forceObjs:Force[] = []
+        const forceObjs = [];
         //handle the different traps
-        trap_objs.forEach(f=>{
-            switch(f.type){                
+        trap_objs.forEach(f => {
+            switch (f.type) {
                 case "mutual_trap":
                     let mutTrap = new MutualTrap();
                     mutTrap.setFromParsedJson(f);
@@ -200,39 +181,39 @@ function readForce(forceFile) {
                     break;
             }
         });
-
         forceHandler.set(forceObjs);
-
         render();
-    })
+    });
 }
-
 // Json files can be a lot of things, read them.
-function parseJson(json:string, system:System) {
+function parseJson(json, system) {
     const data = JSON.parse(json);
+    if (data["_config"]) {
+        const cfg = data["_config"];
+        (cfg.hide || []).forEach(prop => view.setPropertyInScene(prop, system, false));
+        (cfg.show || []).forEach(prop => view.setPropertyInScene(prop, system, true));
+        delete data["_config"]; // don't process it as geometry
+    }
     for (var key in data) {
         if (data[key].length == system.systemLength()) { //if json and dat files match/same length
             if (typeof (data[key][0]) == "number") { //we assume that scalars denote a new color map
                 system.setColorFile(data);
                 makeLut(data, key, system);
                 //update every system's color map
-                systems.forEach(s=>{
-                    s.doVisuals(()=>{
+                systems.forEach(s => {
+                    s.doVisuals(() => {
                         const end = s.systemLength();
-                        for(let j=0; j < end; j++)  //insert lut colors into lutCols[] 
+                        for (let j = 0; j < end; j++) //insert lut colors into lutCols[] 
                             s.lutCols[j] = lut.getColor(Number(s.colormapFile[key][j]));
-                    }) 
+                    });
                 });
                 view.coloringMode.set("Overlay");
-
-                if (key.toLowerCase().includes("binary")){
-                    api.changeColormap("BuPu")
+                if (key.toLowerCase().includes("binary")) {
+                    api.changeColormap("BuPu");
                 }
-                
-
             }
             if (data[key][0].length == 3) { //we assume that 3D vectors denote motion
-                const end = system.systemLength() + system.globalStartId
+                const end = system.systemLength() + system.globalStartId;
                 for (let i = system.globalStartId; i < end; i++) {
                     const vec = new THREE.Vector3(data[key][i][0], data[key][i][1], data[key][i][2]);
                     const len = vec.length();
@@ -243,66 +224,38 @@ function parseJson(json:string, system:System) {
                 }
             }
         }
-        
         else if (data[key][0].length == 6) { // if each entry is 6 elements long
-
             const hasCylinder = key.toLowerCase().includes("cylinder"); // if the key of the dictionary includes the substring "cylinder"
-            const hasLine     = key.toLowerCase().includes("line"); // if the key of the dictionary includes the substring "line"
-
-            if (hasCylinder) {// Draw cyclinders. The first three and the last three values in each entry are the coordinates of the start- and end-points of the axis.
-
-                for (let entry of data[key]) {  
-
+            const hasLine = key.toLowerCase().includes("line"); // if the key of the dictionary includes the substring "line"
+            if (hasCylinder) { // Draw cyclinders. The first three and the last three values in each entry are the coordinates of the start- and end-points of the axis.
+                for (let entry of data[key]) {
                     const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
                     const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
-                    const radius = 0.8
-
+                    const radius = 0.8;
                     const direction = new THREE.Vector3().subVectors(pos2, pos1);
                     const length = direction.length();
-
                     // midpoint for cylinder position
                     const midpoint = new THREE.Vector3().addVectors(pos1, pos2).multiplyScalar(0.5);
-
-                    const geometry = new THREE.CylinderGeometry(radius, radius, length, 64); 
-                    const material = new THREE.MeshStandardMaterial({color:0xff0000 }); // red
+                    const geometry = new THREE.CylinderGeometry(radius, radius, length, 64);
+                    const material = new THREE.MeshStandardMaterial({ color: 0xff0000 }); // red
                     const cylinder = new THREE.Mesh(geometry, material);
-
                     // align cylinder along direction vector (rotate the cylinder so that its y-axis points from pos1 to pos2)
                     cylinder.position.copy(midpoint);
-                    cylinder.quaternion.setFromUnitVectors(
-                        new THREE.Vector3(0, 1, 0), // cylinder default points up along Y
-                        direction.clone().normalize()
-                    );
-
+                    cylinder.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), // cylinder default points up along Y
+                    direction.clone().normalize());
                     scene.add(cylinder);
-
-                    // remove nucleotide and connector for better visualisation
-                    view.setPropertyInScene('nucleoside', system, false);
-                    view.setPropertyInScene('connector', system, false);
                 }
             }
-                
             else if (hasLine) { // Draw lines. The first three and the last three values of each entry are the coordinates of the start- and end-points of the line.
                 for (let entry of data[key]) {
-
                     const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
                     const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
-
                     const geometry = new THREE.BufferGeometry().setFromPoints([pos1, pos2]);
                     const material = new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 0.9 });
                     const line = new THREE.Line(geometry, material); //a red line that starts at pos1 and ends at pos2
                     scene.add(line);
-
-                    // remove nucleotide and connector for better visualisation
-                    view.setPropertyInScene('nucleoside', system, false);
-                    view.setPropertyInScene('connector', system, false);
-                    view.setPropertyInScene('backbone', system, false);
-                    view.setPropertyInScene('bbconnector', system, false);
-
-
                 }
             }
-
             // else { //draw arbitrary arrows on the scene. First three values of each entry are the coordinates for the starting point, the last three make up the vector.
             //     for (let entry of data[key]) {
             //         const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
@@ -312,110 +265,71 @@ function parseJson(json:string, system:System) {
             //         scene.add(arrowHelper);
             //     }
             // }
-
             else { //draw arbitrary arrows on the scene. First three values of each entry are the coordinates for the starting point, the last three make up the vector.
                 for (let entry of data[key]) {
                     const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
                     const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
                     const vec = new THREE.Vector3().subVectors(pos2, pos1);
-
-                    const length = vec.length();  
-                    vec.normalize();  
-
-                    const arrowHelper = new THREE.ArrowHelper(vec, pos1, 0.5*length, 0x000000);
+                    const length = vec.length();
+                    vec.normalize();
+                    const arrowHelper = new THREE.ArrowHelper(vec, pos1, 0.5 * length, 0x000000);
                     scene.add(arrowHelper);
                 }
             }
-
-      
         }
-
         else if (data[key][0].length == 9) { // Draw planes
-            
             const hasPlane = key.toLowerCase().includes("plane"); // if the key of the dictionary includes the substring "plane"
-            const hasPoint    = key.toLowerCase().includes("point"); // if the key of the dictionary includes the substring "point"
-
-
+            const hasPoint = key.toLowerCase().includes("point"); // if the key of the dictionary includes the substring "point"
             if (hasPlane) {
-                for (let entry of data[key]) {  
-
+                for (let entry of data[key]) {
                     const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
                     const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
                     const pos3 = new THREE.Vector3(entry[6], entry[7], entry[8]);
-
-
                     // get the normal vector from the 3 points
                     const v1 = new THREE.Vector3().subVectors(pos2, pos1);
                     const v2 = new THREE.Vector3().subVectors(pos3, pos1);
                     const normal = new THREE.Vector3().crossVectors(v1, v2).normalize();
-
                     // construct the plane
-                    const geometry = new THREE.PlaneGeometry( 7, 7 );
-                    const material = new THREE.MeshBasicMaterial( { color: 0xff0000, side: THREE.DoubleSide, transparent: true, opacity: 0.5 } ); 
-                    const plane = new THREE.Mesh( geometry, material );
-
-                    plane.quaternion.setFromUnitVectors(
-                            new THREE.Vector3(0, 0, 1), 
-                            normal,
-                        );
-
+                    const geometry = new THREE.PlaneGeometry(7, 7);
+                    const material = new THREE.MeshBasicMaterial({ color: 0xff0000, side: THREE.DoubleSide, transparent: true, opacity: 0.5 });
+                    const plane = new THREE.Mesh(geometry, material);
+                    plane.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), normal);
                     // move it such that it goes through point 2 (middle helix?)
                     plane.position.copy(pos2);
-                
                     scene.add(plane);
-                    
                     // remove nucleotide and connector for better visualisation
                     // view.setPropertyInScene('nucleoside', system, true);
                     // view.setPropertyInScene('connector', system, true);
-
                 }
             }
-
             else if (hasPoint) {
-                for (let entry of data[key]) {  
-
+                for (let entry of data[key]) {
                     const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
                     const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
                     const pos3 = new THREE.Vector3(entry[6], entry[7], entry[8]);
-
                     const sphereGeom = new THREE.SphereGeometry(0.1, 16, 16);
-
-                    const mat = new THREE.MeshBasicMaterial({ color: 0x000000});
-
+                    const mat = new THREE.MeshBasicMaterial({ color: 0x000000 });
                     const s1 = new THREE.Mesh(sphereGeom, mat);
                     const s2 = new THREE.Mesh(sphereGeom, mat);
                     const s3 = new THREE.Mesh(sphereGeom, mat);
-
                     s1.position.copy(pos1);
                     s2.position.copy(pos2);
                     s3.position.copy(pos3);
-
                     scene.add(s1);
                     scene.add(s2);
                     scene.add(s3);
                 }
             }
-
         }
-
         else if (data[key][0].length == 3) {
-            for (let entry of data[key]) {  
-
-                    const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
-
-                    const sphereGeom = new THREE.SphereGeometry(0.1, 16, 16);
-                    const mat = new THREE.MeshBasicMaterial({ color: 0x000000});
-                    const s = new THREE.Mesh(sphereGeom, mat);
-
-                    s.position.copy(pos);
-
-                    scene.add(s);
-                    view.setPropertyInScene('backbone', system, true);
-                    view.setPropertyInScene('bbconnector', system, true);
-                    view.setPropertyInScene('nucleoside', system, false);
-                    view.setPropertyInScene('connector', system, false);
-        
-                }
+            for (let entry of data[key]) {
+                const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                const sphereGeom = new THREE.SphereGeometry(0.1, 16, 16);
+                const mat = new THREE.MeshBasicMaterial({ color: 0x000000 });
+                const s = new THREE.Mesh(sphereGeom, mat);
+                s.position.copy(pos);
+                scene.add(s);
+            }
         }
         else { //if json and dat files do not match, display error message and set filesLen to 2 (not necessary)
             notify(".json and .top files are not compatible.", "alert");
@@ -423,195 +337,154 @@ function parseJson(json:string, system:System) {
         }
     }
 }
-
 function readSelectFile(reader) {
     if (systems.length > 1) {
-        notify("Warning: Selection files select on global ID, not system ID.  There are multiple systems loaded.", 'warning')
+        notify("Warning: Selection files select on global ID, not system ID.  There are multiple systems loaded.", 'warning');
     }
-    const ids = (reader.result as string).split(' ').map(function(i) {
-        return parseInt(i, 10)
+    const ids = reader.result.split(' ').map(function (i) {
+        return parseInt(i, 10);
     });
-    api.selectElementIDs(ids, true)
+    api.selectElementIDs(ids, true);
 }
-
 //reads in an anm parameter file and associates it with the last loaded system.
 function parsePar(lines, system) {
-
     lines = lines.split(/[\n]+/g);
     //remove the header
-    lines = lines.slice(1)
-
+    lines = lines.slice(1);
     const size = lines.length;
-
     //create an ANM object to allow visualization
     const net = new Network(networks.length, system.getAAMonomers());
-
     //process connections
     for (let i = 0; i < size; i++) {
-        let l = lines[i].split(/\s+/)
+        let l = lines[i].split(/\s+/);
         //extract values
-        const p = parseInt(l[0]),
-            q = parseInt(l[1]),
-            eqDist = parseFloat(l[2]),
-            type = l[3],
-            strength = parseFloat(l[4]);
-        
+        const p = parseInt(l[0]), q = parseInt(l[1]), eqDist = parseFloat(l[2]), type = l[3], strength = parseFloat(l[4]);
         if (!Number.isInteger(p) || !Number.isInteger(q) || !Number.isFinite(eqDist) || !Number.isFinite(strength)) {
-            notify("Cannot read par file, see console for bad line", 'error')
-            console.log("Error on par line", i)
-            console.log(l)
-            return
+            notify("Cannot read par file, see console for bad line", 'error');
+            console.log("Error on par line", i);
+            console.log(l);
+            return;
         }
-
         // if its a torsional ANM then there are additional parameters on some lines
-        let extraParams = []
+        let extraParams = [];
         if (l.length > 5) {
             for (let i = 5; i < l.length; i++) {
-                extraParams.push(l[i])
+                extraParams.push(l[i]);
             }
         }
-        if(Number.isInteger(p) && Number.isInteger(q)){
+        if (Number.isInteger(p) && Number.isInteger(q)) {
             net.reducedEdges.addEdge(p, q, eqDist, type, strength, extraParams);
         }
-    };
+    }
+    ;
     // Create and Fill Vectors
     net.initInstances(net.reducedEdges.total);
     net.initEdges();
     net.fillConnections(); // fills connection array for
     net.networktype = "par";
-
     net.prepVis(); // Creates Mesh for visualization
     networks.push(net); // Any network added here shows up in UI network selector
     selectednetwork = net.nid; // auto select network just loaded
     view.addNetwork(net.nid);
-
-    notify("Par file read! Turn on visualization in the Protein tab")
+    notify("Par file read! Turn on visualization in the Protein tab");
 }
-
 // reads hydrogen bonding file generated with Chimera
 // hbondinfo is then stored in the pdbfiledatasets
 function readHBondFile(file) {
     let reader = new FileReader();
     let pdbInfoIndx = pdbFileInfo.length - 1;
-
-    if(pdbInfoIndx == -1){
+    if (pdbInfoIndx == -1) {
         notify("Please Load PDB file to associate H-Bond file with");
         return;
     }
-
     reader.onload = () => {
-        let lines = (reader.result as string).split(/[\n]+/g);
+        let lines = reader.result.split(/[\n]+/g);
         const size = lines.length;
         let hbonds = [];
-
         //process hbonds
-        for (let i = 0; i < size-1; i++) {
+        for (let i = 0; i < size - 1; i++) {
             // trims all split items then removes the empty strings
-            let l = lines[i].split(/\s+/).map(function(item) {return item.trim()}).filter(n => n);
+            let l = lines[i].split(/\s+/).map(function (item) { return item.trim(); }).filter(n => n);
             if (recongizedProteinResidues.indexOf(l[0]) != -1) { //check that its a protein residue
                 //extract values
-                const pos1 = l[1].split("."),
-                    atm1 = l[2],
-                    id2 = l[3],
-                    pos2 = l[4].split("."),
-                    atm2 = l[5],
-                    dist = parseFloat(l[8]);
-
-                if(recongizedProteinResidues.indexOf(id2) != -1) { //bonded to another protein residue
+                const pos1 = l[1].split("."), atm1 = l[2], id2 = l[3], pos2 = l[4].split("."), atm2 = l[5], dist = parseFloat(l[8]);
+                if (recongizedProteinResidues.indexOf(id2) != -1) { //bonded to another protein residue
                     // Chain Identifier, residue number
                     let pdbinds1 = [pos1[1], parseInt(pos1[0])];
                     let pdbinds2 = [pos2[1], parseInt(pos2[0])];
-
                     let hbond = [pdbinds1, pdbinds2];
                     hbonds.push(hbond);
                 }
                 // can read hbonds using just model identifiers (no chain identifiers)
-            } else if (recongizedProteinResidues.indexOf(l[1]) != -1 && recongizedProteinResidues.indexOf(l[5]) != -1) { // residue is second listed indicates hbonds listed from models
+            }
+            else if (recongizedProteinResidues.indexOf(l[1]) != -1 && recongizedProteinResidues.indexOf(l[5]) != -1) { // residue is second listed indicates hbonds listed from models
                 //extract values
-                const pos1 = l[0].split(".")[1],
-                    atm1 = l[3],
-                    id1 = l[2],
-                    id2 = l[6],
-                    pos2 = l[4].split(".")[1],
-                    atm2 = l[7],
-                    dist = parseFloat(l[10]);
-
+                const pos1 = l[0].split(".")[1], atm1 = l[3], id1 = l[2], id2 = l[6], pos2 = l[4].split(".")[1], atm2 = l[7], dist = parseFloat(l[10]);
                 let pdbinds1 = [pos1, parseInt(id1)];
                 let pdbinds2 = [pos2, parseInt(id2)];
-
                 let hbond = [pdbinds1, pdbinds2];
                 hbonds.push(hbond);
             }
         }
-        if(hbonds.length == 0) notify("H bond file format is unrecongized");
+        if (hbonds.length == 0)
+            notify("H bond file format is unrecongized");
         pdbFileInfo[pdbInfoIndx].hydrogenBonds = hbonds;
-    }
+    };
     reader.readAsText(file);
 }
-
 // associates massfile with last loaded system (only needed for Generic Sphere Systems)
-function readMassFile(reader){
-    let lines = (reader.result as string).split(/[\n]+/g);
-    let key ={
+function readMassFile(reader) {
+    let lines = reader.result.split(/[\n]+/g);
+    let key = {
         indx: [],
         mass: [],
         radius: []
-    }
-
-    if(parseInt(lines[0]) > 27){  // subtypes 0-27 taken by dna/protein subtypes
+    };
+    if (parseInt(lines[0]) > 27) { // subtypes 0-27 taken by dna/protein subtypes
         //remove the header
-        lines = lines.slice(1)
+        lines = lines.slice(1);
         const size = lines.length;
         for (let i = 0; i < size; i++) {
-            let l = lines[i].split(/\s+/)
+            let l = lines[i].split(/\s+/);
             //extract values
-            const p = parseInt(l[0]),
-                mass = parseInt(l[1]),
-                radius = parseFloat(l[2]);
-
-            if(p > 26){
-                key.indx.push(p-27);
+            const p = parseInt(l[0]), mass = parseInt(l[1]), radius = parseFloat(l[2]);
+            if (p > 26) {
+                key.indx.push(p - 27);
                 key.mass.push(mass);
                 key.radius.push(radius);
             }
-
         }
-
         // change all generic sphere radius and mass according to mass file
         let sub, indx, gs;
         systems.forEach(sys => {
             sys.strands.forEach(strand => {
-                if(strand.isGS()){
+                if (strand.isGS()) {
                     let mon = strand.getMonomers();
                     mon.forEach(be => {
-                        sub = parseInt(be.type.substring(2))
+                        sub = parseInt(be.type.substring(2));
                         indx = key.indx.indexOf(sub);
-                        if(indx == -1){
+                        if (indx == -1) {
                             console.log("Subtype " + sub.toString() + " not found in the provided mass file");
-                        } else {
-                            gs = <GenericSphere>be;
+                        }
+                        else {
+                            gs = be;
                             gs.updateSize(key.mass[indx], key.radius[indx]);
                         }
-                    })
+                    });
                 }
-            })
-        })
-
-
-    } else {
-        console.log("No GS Masses in file, (no subtype over 27), double check header")
+            });
+        });
+    }
+    else {
+        console.log("No GS Masses in file, (no subtype over 27), double check header");
     }
 }
-
-
-function parseDotBracket(input: string): number[] {
+function parseDotBracket(input) {
     // Converts a dot-bracket string to a list of paired nucleotides.
-
-    const output: number[] = new Array(input.length).fill(-1);
-    const parenQueue: number[] = [];
-    const squareQueue: number[] = [];
-    const curlyQueue: number[] = [];
-
+    const output = new Array(input.length).fill(-1);
+    const parenQueue = [];
+    const squareQueue = [];
+    const curlyQueue = [];
     for (let i = 0; i < input.trim().length; i++) {
         const c = input[i];
         switch (c) {
@@ -654,16 +527,14 @@ function parseDotBracket(input: string): number[] {
                 throw new Error(`Encountered invalid character '${c}' in dot bracket`);
         }
     }
-
     return output;
 }
-
-function readDotBracket(file:File){
-    const updateForceHandler = (forces:Force[])=>{
-        forceHandler.set(forces)
-        render()
-    }
-    file.text().then(txt=>{
+function readDotBracket(file) {
+    const updateForceHandler = (forces) => {
+        forceHandler.set(forces);
+        render();
+    };
+    file.text().then(txt => {
         // let's define the input db format as follows:
         // - each line can be a db string or a sequence
         // - they have to alternate and be separated by a newline
@@ -673,91 +544,85 @@ function readDotBracket(file:File){
         // - if it finds one, it will create a trap between the bases according to the db string
         // - if the file contains only 1 line it has to be a db string and the trap will be created for the last system for all strands with the same length as the db string
         // - unless there are selected bases, in which case the trap will be created only for the selected bases
-
         // preprocess the file
         // strip spaces and newlines
-        const forces: PairwiseForce[] = []
-        let lines = txt.split("\n").map(s=>s.replace(/\s/g,'')).filter(s=>s.length>0)
-
+        const forces = [];
+        let lines = txt.split("\n").map(s => s.replace(/\s/g, '')).filter(s => s.length > 0);
         // now let's parse the file
-        let file_length = lines.length
-        let db_strings = []
-        let sequences = []
-        
-        for (let i = 0; i < file_length; i++){
-            if (i % 2 == 0){
-                db_strings.push(lines[i])
-            } else {
-                sequences.push(lines[i])
+        let file_length = lines.length;
+        let db_strings = [];
+        let sequences = [];
+        for (let i = 0; i < file_length; i++) {
+            if (i % 2 == 0) {
+                db_strings.push(lines[i]);
+            }
+            else {
+                sequences.push(lines[i]);
             }
         }
-
         // if we have only one line, it has to be a db string
-        if (db_strings.length == 1 && sequences.length == 0){
-            let db_string = db_strings[0]
-            let pairs = parseDotBracket(db_string)
-
+        if (db_strings.length == 1 && sequences.length == 0) {
+            let db_string = db_strings[0];
+            let pairs = parseDotBracket(db_string);
             // we always work with either the last system or the selectedBases
             let to_process;
             // so do we have selected bases ? 
             if (selectedBases.size > 0) {
                 // we do and do only on selectedBases
-                to_process = [[... selectedBases].sort( (a,b)=> a.id - b.id)]
+                to_process = [[...selectedBases].sort((a, b) => a.id - b.id)];
                 if (to_process[0].length != db_string.length)
-                    to_process = [] //make sure we have enough bases selected 
+                    to_process = []; //make sure we have enough bases selected 
             }
             else {
                 // we work with the last system
-                to_process = systems[systems.length-1].strands.filter(strand => strand.getLength() == db_string.length).map( s=> s.getMonomers())
+                to_process = systems[systems.length - 1].strands.filter(strand => strand.getLength() == db_string.length).map(s => s.getMonomers());
             }
-
-            to_process.forEach( elements => {
-                pairs.forEach( (pair, i) => {
+            to_process.forEach(elements => {
+                pairs.forEach((pair, i) => {
                     if (pair != -1) {
                         // if pair
-                        let trap = new MutualTrap()
-                        trap.set(elements[i],elements[pair],.09,1.2,1)
-                        forces.push(trap)
+                        let trap = new MutualTrap();
+                        trap.set(elements[i], elements[pair], .09, 1.2, 1);
+                        forces.push(trap);
                     }
-                })
-            })
-            updateForceHandler(forces)
-            return
+                });
+            });
+            updateForceHandler(forces);
+            return;
         }
-
         // check if the file is valid
-        if (db_strings.length != sequences.length){
-            notify("Invalid dot bracket file format")
-            return
+        if (db_strings.length != sequences.length) {
+            notify("Invalid dot bracket file format");
+            return;
         }
-
         // if we have multiple lines, we have to search the strands for the subsequences
         // and we'll use the first match we find
-        
-        for (let i = 0; i < sequences.length; i++){
-            let to_process = []
-            let db_string = db_strings[i]
-            let seq = sequences[i]
-            let pairs = parseDotBracket(db_string)
-            let strands = systems[systems.length-1].strands.forEach( strand => {
+        for (let i = 0; i < sequences.length; i++) {
+            let to_process = [];
+            let db_string = db_strings[i];
+            let seq = sequences[i];
+            let pairs = parseDotBracket(db_string);
+            let strands = systems[systems.length - 1].strands.forEach(strand => {
                 // check if strand is NucleicAcidStrand
-                if (! (strand instanceof NucleicAcidStrand)){ return }
-                let matches = strand.search(seq);
-                if (matches.length > 0){
-                    to_process.push(matches[0])
+                if (!(strand instanceof NucleicAcidStrand)) {
+                    return;
                 }
-            })
-            to_process.forEach( elements => {
-                pairs.forEach( (pair, i) => {
+                let matches = strand.search(seq);
+                if (matches.length > 0) {
+                    to_process.push(matches[0]);
+                }
+            });
+            to_process.forEach(elements => {
+                pairs.forEach((pair, i) => {
                     if (pair != -1) {
                         // if pair
-                        let trap = new MutualTrap()
-                        trap.set(elements[i],elements[pair],.09,1.2,1)
-                        forces.push(trap)
+                        let trap = new MutualTrap();
+                        trap.set(elements[i], elements[pair], .09, 1.2, 1);
+                        forces.push(trap);
                     }
-                })
-            })
-            updateForceHandler(forces)
-        }  
-    })
+                });
+            });
+            updateForceHandler(forces);
+        }
+    });
 }

--- a/dist/file_handling/aux_readers.js
+++ b/dist/file_handling/aux_readers.js
@@ -1,157 +1,176 @@
 /// <reference path="../typescript_definitions/index.d.ts" />
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////               Read a file, modify the scene                ////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-function readTraj(trajFile, system) {
+
+function readTraj(trajFile:File, system:System):Promise<string> {
     system.reader = new TrajectoryReader(trajFile, system);
-    return system.reader.lookupReader.promise;
+    return system.reader.lookupReader.promise
 }
-function readJson(jsonFile, system) {
-    return parseFileWith(jsonFile, parseJson, [system]);
+
+function readJson(jsonFile:File, system:System){ // this still doesn't work for some reason.  It might be a bigger problem tho.
+    return parseFileWith(jsonFile, parseJson, [system])
 }
-function readParFile(parFile, system) {
-    return parseFileWith(parFile, parsePar, [system]);
+
+function readParFile(parFile:File, system:System) {
+    return parseFileWith(parFile, parsePar, [system])
 }
+
 // Nicer lower and upper bound 
 function roundRange(arr) {
-    let min = arr[0], max = arr[0];
-    for (let i = 0; i < arr.length; i++) {
-        if (min > arr[i])
-            min = arr[i];
-        if (max < arr[i])
-            max = arr[i];
-    }
-    const roundedMin = Math.floor(min) + (min % 1 >= 0.5 ? 0.5 : 0);
-    const roundedMax = Math.ceil(max) - (max % 1 > 0 && max % 1 <= 0.5 ? 0.5 : 0);
-    return [roundedMin, roundedMax];
+  let min = arr[0], max = arr[0];
+  for(let i = 0; i < arr.length; i++)
+  {
+      if(min > arr[i]) min = arr[i];
+      if(max < arr[i]) max = arr[i];
+  }
+  
+  const roundedMin = Math.floor(min) + (min % 1 >= 0.5 ? 0.5 : 0);
+  const roundedMax = Math.ceil(max) - (max % 1 > 0 && max % 1 <= 0.5 ? 0.5 : 0);
+
+  return [roundedMin, roundedMax];
 }
+
 // Creates color overlays
 function makeLut(data, key, system) {
+
     let arr = data[key];
     let [min, max] = roundRange(arr);
+   
     // we have no Lut 
-    if (lut == undefined) {
+    if (lut == undefined){
+        
         lut = new THREE.Lut(defaultColormap, 500);
         lut.setMax(max);
-        lut.setMin(min);
+        lut.setMin(min); 
     }
+
     // we need update 
-    if (max > lut.maxV) {
+    if (max > lut.maxV){
         lut.setMax(max);
         api.removeColorbar();
     }
-    if (min < lut.minV) {
+    if (min < lut.minV){
         lut.setMin(min);
         api.removeColorbar();
     }
+
+
     lut.setLegendOn({ 'layout': 'horizontal', 'position': { 'x': 0, 'y': 0, 'z': 0 }, 'dimensions': { 'width': 2, 'height': 12 } }); //create legend
     lut.setLegendLabels({ 'title': key, 'ticks': 5 }); //set up legend format 
 }
+
 // export the current camera position
-const exportCam = () => {
+const exportCam = ()=>{
     const cam = {
         position: camera.position,
         rotation: camera.rotation,
         up: camera.up,
         target: controls.target,
-    };
+    }
     const camJSON = JSON.stringify(cam);
     makeTextFile("camera.cam", camJSON);
-};
+}
 // Read a camera export file
-const readCamFile = (file) => {
-    file.text().then(txt => {
+const readCamFile = (file:File)=>{
+    file.text().then(txt=>{
         const cam = JSON.parse(txt);
-        camera.position.set(cam.position.x, cam.position.y, cam.position.z);
-        camera.rotation.set(cam.rotation.x, cam.rotation.y, cam.rotation.z);
-        camera.up.set(cam.up.x, cam.up.y, cam.up.z);
-        controls.target.set(cam.target.x, cam.target.y, cam.target.z);
-    });
-};
+        camera.position.set(cam.position.x,cam.position.y,cam.position.z);
+        camera.rotation.set(cam.rotation.x,cam.rotation.y,cam.rotation.z);
+        camera.up.set(cam.up.x,cam.up.y,cam.up.z);
+        controls.target.set(cam.target.x,cam.target.y,cam.target.z);
+    })
+}
+
 // Highlight sequences found in cadnano or sequence csv
-const handleCSV = (file) => {
+const handleCSV = (file:File)=>{
     // highlight all the sequences complying with the cadnano file
     // or a line by line sequence file 
-    const search_func = (system, seq) => {
+    const search_func = (system,seq) => {
         system.strands.forEach(strand => {
             strand.search(seq).forEach(match => {
                 api.selectElements(match, true);
             });
         });
     };
-    const cadnano_line_to_seq = (line) => line.split(",")[2].replaceAll("?", "N").toUpperCase().trim();
-    const reg_line = (line) => line.replaceAll("?", "N").toUpperCase().trim();
+
+    const cadnano_line_to_seq = (line)=> line.split(",")[2].replaceAll("?","N").toUpperCase().trim();
+    const reg_line = (line)=> line.replaceAll("?","N").toUpperCase().trim();
+
     //read in a cadnano csv sequence file and highlight them in the scene
-    file.text().then(txt => {
+    file.text().then(txt=>{
         let lines = txt.split("\n");
         let len = lines.length;
         let start_id = 0;
+
         //we handle bothe cadnano and just regular lists
         let processor = reg_line;
-        if (lines[0].startsWith("Start,End,Sequence,Length,Color")) {
-            start_id = 1;
-            processor = cadnano_line_to_seq;
+        if (lines[0].startsWith("Start,End,Sequence,Length,Color")){
+            start_id=1;
+            processor= cadnano_line_to_seq;
         }
-        for (let i = start_id; i < len; i++) {
-            if (lines[i]) {
-                let seq = processor(lines[i]);
-                console.log(seq);
-                systems.forEach(sys => search_func(sys, seq));
-                tmpSystems.forEach(sys => search_func(sys, seq));
+        for(let i=start_id; i<len;i++){
+            if(lines[i]){
+            let seq = processor(lines[i]);
+            console.log(seq)
+            systems.forEach(sys => search_func(sys,seq));
+            tmpSystems.forEach(sys => search_func(sys,seq));
             }
         }
         render();
+            
     });
-};
+}
+
 function readForce(forceFile) {
-    forceFile.text().then(text => {
+    forceFile.text().then(text=>{
         //{ can be replaced with \n to make sure no parameter is lost
-        while (text.indexOf("{") >= 0)
-            text = text.replace("{", "\n");
+        while(text.indexOf("{")>=0)
+            text = text.replace("{","\n");
         // forces can be split by } because everything between {} is one force
         let forceTxt = text.split("}");
+
         let trap_objs = [];
-        forceTxt.forEach((force) => {
+        forceTxt.forEach((force) =>{
             let lines = force.split('\n');
-            //empty lines and empty traps need not be processed as well as comments
-            lines = lines.filter((line) => line !== "" && !line.startsWith("#"));
-            if (lines.length == 0)
-                return;
+                //empty lines and empty traps need not be processed as well as comments
+            lines = lines.filter((line)=> line !== "" && !line.startsWith("#"));
+            if(lines.length == 0) return;
+
             let trap_obj = {};
-            lines.forEach((line) => {
+            lines.forEach((line)  =>{
                 // remove comments
                 let com_pos = line.indexOf("#");
-                if (com_pos >= 0)
-                    line = line.slice(0, com_pos).trim();
+                if (com_pos >= 0) line =  line.slice(0, com_pos).trim();
                 // another chance an empty line can be encountered. Remove whitespace
-                if (line.trim().length == 0)
-                    return;
+                if(line.trim().length == 0) return;
                 // split into option name and value
                 let options = line.split("=");
                 let lft = options[0].trim();
                 let rght = options[1].trim();
+
                 // Check if the string represents a list of floats (numbers separated by commas)
                 if (rght.includes(',')) {
                     // Split the string by commas and convert each part to a float
                     let floatList = rght.split(',').map(Number);
                     trap_obj[lft] = floatList;
-                }
-                else if (/^-?\d+(\.\d+)?$/.test(rght)) {
+                } else if (/^-?\d+(\.\d+)?$/.test(rght)) {
                     // Check if the entire string is a valid number
                     trap_obj[lft] = parseFloat(rght);
-                }
-                else {
+                } else {
                     // Otherwise, treat it as a string
                     trap_obj[lft] = rght;
                 }
             });
-            if (Object.keys(trap_obj).length > 0)
+            if(Object.keys(trap_obj).length > 0)
                 trap_objs.push(trap_obj);
         });
-        const forceObjs = [];
+
+        const forceObjs:Force[] = []
         //handle the different traps
-        trap_objs.forEach(f => {
-            switch (f.type) {
+        trap_objs.forEach(f=>{
+            switch(f.type){                
                 case "mutual_trap":
                     let mutTrap = new MutualTrap();
                     mutTrap.setFromParsedJson(f);
@@ -181,12 +200,15 @@ function readForce(forceFile) {
                     break;
             }
         });
+
         forceHandler.set(forceObjs);
+
         render();
-    });
+    })
 }
+
 // Json files can be a lot of things, read them.
-function parseJson(json, system) {
+function parseJson(json:string, system:System) {
     const data = JSON.parse(json);
     for (var key in data) {
         if (data[key].length == system.systemLength()) { //if json and dat files match/same length
@@ -194,17 +216,23 @@ function parseJson(json, system) {
                 system.setColorFile(data);
                 makeLut(data, key, system);
                 //update every system's color map
-                systems.forEach(s => {
-                    s.doVisuals(() => {
+                systems.forEach(s=>{
+                    s.doVisuals(()=>{
                         const end = s.systemLength();
-                        for (let j = 0; j < end; j++) //insert lut colors into lutCols[] 
+                        for(let j=0; j < end; j++)  //insert lut colors into lutCols[] 
                             s.lutCols[j] = lut.getColor(Number(s.colormapFile[key][j]));
-                    });
+                    }) 
                 });
                 view.coloringMode.set("Overlay");
+
+                if (key.toLowerCase().includes("binary")){
+                    api.changeColormap("BuPu")
+                }
+                
+
             }
             if (data[key][0].length == 3) { //we assume that 3D vectors denote motion
-                const end = system.systemLength() + system.globalStartId;
+                const end = system.systemLength() + system.globalStartId
                 for (let i = system.globalStartId; i < end; i++) {
                     const vec = new THREE.Vector3(data[key][i][0], data[key][i][1], data[key][i][2]);
                     const len = vec.length();
@@ -215,53 +243,179 @@ function parseJson(json, system) {
                 }
             }
         }
+        
         else if (data[key][0].length == 6) { // if each entry is 6 elements long
+
             const hasCylinder = key.toLowerCase().includes("cylinder"); // if the key of the dictionary includes the substring "cylinder"
-            const hasLine = key.toLowerCase().includes("line"); // if the key of the dictionary includes the substring "line"
-            if (hasCylinder) { // Draw cyclinders. The first three and the last three values in each entry are the coordinates of the start- and end-points of the axis.
-                for (let entry of data[key]) {
+            const hasLine     = key.toLowerCase().includes("line"); // if the key of the dictionary includes the substring "line"
+
+            if (hasCylinder) {// Draw cyclinders. The first three and the last three values in each entry are the coordinates of the start- and end-points of the axis.
+
+                for (let entry of data[key]) {  
+
                     const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
                     const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
-                    const radius = 0.8;
+                    const radius = 0.8
+
                     const direction = new THREE.Vector3().subVectors(pos2, pos1);
                     const length = direction.length();
+
                     // midpoint for cylinder position
                     const midpoint = new THREE.Vector3().addVectors(pos1, pos2).multiplyScalar(0.5);
-                    const geometry = new THREE.CylinderGeometry(radius, radius, length, 64);
-                    const material = new THREE.MeshStandardMaterial({ color: 0xff0000 }); // red
+
+                    const geometry = new THREE.CylinderGeometry(radius, radius, length, 64); 
+                    const material = new THREE.MeshStandardMaterial({color:0xff0000 }); // red
                     const cylinder = new THREE.Mesh(geometry, material);
+
                     // align cylinder along direction vector (rotate the cylinder so that its y-axis points from pos1 to pos2)
                     cylinder.position.copy(midpoint);
-                    cylinder.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), // cylinder default points up along Y
-                    direction.clone().normalize());
+                    cylinder.quaternion.setFromUnitVectors(
+                        new THREE.Vector3(0, 1, 0), // cylinder default points up along Y
+                        direction.clone().normalize()
+                    );
+
                     scene.add(cylinder);
+
                     // remove nucleotide and connector for better visualisation
                     view.setPropertyInScene('nucleoside', system, false);
                     view.setPropertyInScene('connector', system, false);
                 }
             }
+                
             else if (hasLine) { // Draw lines. The first three and the last three values of each entry are the coordinates of the start- and end-points of the line.
                 for (let entry of data[key]) {
+
                     const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
                     const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+
                     const geometry = new THREE.BufferGeometry().setFromPoints([pos1, pos2]);
                     const material = new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 0.9 });
                     const line = new THREE.Line(geometry, material); //a red line that starts at pos1 and ends at pos2
                     scene.add(line);
+
                     // remove nucleotide and connector for better visualisation
                     view.setPropertyInScene('nucleoside', system, false);
                     view.setPropertyInScene('connector', system, false);
+                    view.setPropertyInScene('backbone', system, false);
+                    view.setPropertyInScene('bbconnector', system, false);
+
+
                 }
             }
+
+            // else { //draw arbitrary arrows on the scene. First three values of each entry are the coordinates for the starting point, the last three make up the vector.
+            //     for (let entry of data[key]) {
+            //         const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
+            //         const vec = new THREE.Vector3(entry[3], entry[4], entry[5]);
+            //         vec.normalize();
+            //         const arrowHelper = new THREE.ArrowHelper(vec, pos, 5 * vec.length(), 0x00000);
+            //         scene.add(arrowHelper);
+            //     }
+            // }
+
             else { //draw arbitrary arrows on the scene. First three values of each entry are the coordinates for the starting point, the last three make up the vector.
                 for (let entry of data[key]) {
-                    const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
-                    const vec = new THREE.Vector3(entry[3], entry[4], entry[5]);
-                    vec.normalize();
-                    const arrowHelper = new THREE.ArrowHelper(vec, pos, 5 * vec.length(), 0x00000);
+                    const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    const vec = new THREE.Vector3().subVectors(pos2, pos1);
+
+                    const length = vec.length();  
+                    vec.normalize();  
+
+                    const arrowHelper = new THREE.ArrowHelper(vec, pos1, 0.5*length, 0x000000);
                     scene.add(arrowHelper);
                 }
             }
+
+      
+        }
+
+        else if (data[key][0].length == 9) { // Draw planes
+            
+            const hasPlane = key.toLowerCase().includes("plane"); // if the key of the dictionary includes the substring "plane"
+            const hasPoint    = key.toLowerCase().includes("point"); // if the key of the dictionary includes the substring "point"
+
+
+            if (hasPlane) {
+                for (let entry of data[key]) {  
+
+                    const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    const pos3 = new THREE.Vector3(entry[6], entry[7], entry[8]);
+
+
+                    // get the normal vector from the 3 points
+                    const v1 = new THREE.Vector3().subVectors(pos2, pos1);
+                    const v2 = new THREE.Vector3().subVectors(pos3, pos1);
+                    const normal = new THREE.Vector3().crossVectors(v1, v2).normalize();
+
+                    // construct the plane
+                    const geometry = new THREE.PlaneGeometry( 7, 7 );
+                    const material = new THREE.MeshBasicMaterial( { color: 0xff0000, side: THREE.DoubleSide, transparent: true, opacity: 0.5 } ); 
+                    const plane = new THREE.Mesh( geometry, material );
+
+                    plane.quaternion.setFromUnitVectors(
+                            new THREE.Vector3(0, 0, 1), 
+                            normal,
+                        );
+
+                    // move it such that it goes through point 2 (middle helix?)
+                    plane.position.copy(pos2);
+                
+                    scene.add(plane);
+                    
+                    // remove nucleotide and connector for better visualisation
+                    // view.setPropertyInScene('nucleoside', system, true);
+                    // view.setPropertyInScene('connector', system, true);
+
+                }
+            }
+
+            else if (hasPoint) {
+                for (let entry of data[key]) {  
+
+                    const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    const pos3 = new THREE.Vector3(entry[6], entry[7], entry[8]);
+
+                    const sphereGeom = new THREE.SphereGeometry(0.1, 16, 16);
+
+                    const mat = new THREE.MeshBasicMaterial({ color: 0x000000});
+
+                    const s1 = new THREE.Mesh(sphereGeom, mat);
+                    const s2 = new THREE.Mesh(sphereGeom, mat);
+                    const s3 = new THREE.Mesh(sphereGeom, mat);
+
+                    s1.position.copy(pos1);
+                    s2.position.copy(pos2);
+                    s3.position.copy(pos3);
+
+                    scene.add(s1);
+                    scene.add(s2);
+                    scene.add(s3);
+                }
+            }
+
+        }
+
+        else if (data[key][0].length == 3) {
+            for (let entry of data[key]) {  
+
+                    const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
+
+                    const sphereGeom = new THREE.SphereGeometry(0.1, 16, 16);
+                    const mat = new THREE.MeshBasicMaterial({ color: 0x000000});
+                    const s = new THREE.Mesh(sphereGeom, mat);
+
+                    s.position.copy(pos);
+
+                    scene.add(s);
+                    view.setPropertyInScene('backbone', system, true);
+                    view.setPropertyInScene('bbconnector', system, true);
+                    view.setPropertyInScene('nucleoside', system, false);
+                    view.setPropertyInScene('connector', system, false);
+        
+                }
         }
         else { //if json and dat files do not match, display error message and set filesLen to 2 (not necessary)
             notify(".json and .top files are not compatible.", "alert");
@@ -269,154 +423,195 @@ function parseJson(json, system) {
         }
     }
 }
+
 function readSelectFile(reader) {
     if (systems.length > 1) {
-        notify("Warning: Selection files select on global ID, not system ID.  There are multiple systems loaded.", 'warning');
+        notify("Warning: Selection files select on global ID, not system ID.  There are multiple systems loaded.", 'warning')
     }
-    const ids = reader.result.split(' ').map(function (i) {
-        return parseInt(i, 10);
+    const ids = (reader.result as string).split(' ').map(function(i) {
+        return parseInt(i, 10)
     });
-    api.selectElementIDs(ids, true);
+    api.selectElementIDs(ids, true)
 }
+
 //reads in an anm parameter file and associates it with the last loaded system.
 function parsePar(lines, system) {
+
     lines = lines.split(/[\n]+/g);
     //remove the header
-    lines = lines.slice(1);
+    lines = lines.slice(1)
+
     const size = lines.length;
+
     //create an ANM object to allow visualization
     const net = new Network(networks.length, system.getAAMonomers());
+
     //process connections
     for (let i = 0; i < size; i++) {
-        let l = lines[i].split(/\s+/);
+        let l = lines[i].split(/\s+/)
         //extract values
-        const p = parseInt(l[0]), q = parseInt(l[1]), eqDist = parseFloat(l[2]), type = l[3], strength = parseFloat(l[4]);
+        const p = parseInt(l[0]),
+            q = parseInt(l[1]),
+            eqDist = parseFloat(l[2]),
+            type = l[3],
+            strength = parseFloat(l[4]);
+        
         if (!Number.isInteger(p) || !Number.isInteger(q) || !Number.isFinite(eqDist) || !Number.isFinite(strength)) {
-            notify("Cannot read par file, see console for bad line", 'error');
-            console.log("Error on par line", i);
-            console.log(l);
-            return;
+            notify("Cannot read par file, see console for bad line", 'error')
+            console.log("Error on par line", i)
+            console.log(l)
+            return
         }
+
         // if its a torsional ANM then there are additional parameters on some lines
-        let extraParams = [];
+        let extraParams = []
         if (l.length > 5) {
             for (let i = 5; i < l.length; i++) {
-                extraParams.push(l[i]);
+                extraParams.push(l[i])
             }
         }
-        if (Number.isInteger(p) && Number.isInteger(q)) {
+        if(Number.isInteger(p) && Number.isInteger(q)){
             net.reducedEdges.addEdge(p, q, eqDist, type, strength, extraParams);
         }
-    }
-    ;
+    };
     // Create and Fill Vectors
     net.initInstances(net.reducedEdges.total);
     net.initEdges();
     net.fillConnections(); // fills connection array for
     net.networktype = "par";
+
     net.prepVis(); // Creates Mesh for visualization
     networks.push(net); // Any network added here shows up in UI network selector
     selectednetwork = net.nid; // auto select network just loaded
     view.addNetwork(net.nid);
-    notify("Par file read! Turn on visualization in the Protein tab");
+
+    notify("Par file read! Turn on visualization in the Protein tab")
 }
+
 // reads hydrogen bonding file generated with Chimera
 // hbondinfo is then stored in the pdbfiledatasets
 function readHBondFile(file) {
     let reader = new FileReader();
     let pdbInfoIndx = pdbFileInfo.length - 1;
-    if (pdbInfoIndx == -1) {
+
+    if(pdbInfoIndx == -1){
         notify("Please Load PDB file to associate H-Bond file with");
         return;
     }
+
     reader.onload = () => {
-        let lines = reader.result.split(/[\n]+/g);
+        let lines = (reader.result as string).split(/[\n]+/g);
         const size = lines.length;
         let hbonds = [];
+
         //process hbonds
-        for (let i = 0; i < size - 1; i++) {
+        for (let i = 0; i < size-1; i++) {
             // trims all split items then removes the empty strings
-            let l = lines[i].split(/\s+/).map(function (item) { return item.trim(); }).filter(n => n);
+            let l = lines[i].split(/\s+/).map(function(item) {return item.trim()}).filter(n => n);
             if (recongizedProteinResidues.indexOf(l[0]) != -1) { //check that its a protein residue
                 //extract values
-                const pos1 = l[1].split("."), atm1 = l[2], id2 = l[3], pos2 = l[4].split("."), atm2 = l[5], dist = parseFloat(l[8]);
-                if (recongizedProteinResidues.indexOf(id2) != -1) { //bonded to another protein residue
+                const pos1 = l[1].split("."),
+                    atm1 = l[2],
+                    id2 = l[3],
+                    pos2 = l[4].split("."),
+                    atm2 = l[5],
+                    dist = parseFloat(l[8]);
+
+                if(recongizedProteinResidues.indexOf(id2) != -1) { //bonded to another protein residue
                     // Chain Identifier, residue number
                     let pdbinds1 = [pos1[1], parseInt(pos1[0])];
                     let pdbinds2 = [pos2[1], parseInt(pos2[0])];
+
                     let hbond = [pdbinds1, pdbinds2];
                     hbonds.push(hbond);
                 }
                 // can read hbonds using just model identifiers (no chain identifiers)
-            }
-            else if (recongizedProteinResidues.indexOf(l[1]) != -1 && recongizedProteinResidues.indexOf(l[5]) != -1) { // residue is second listed indicates hbonds listed from models
+            } else if (recongizedProteinResidues.indexOf(l[1]) != -1 && recongizedProteinResidues.indexOf(l[5]) != -1) { // residue is second listed indicates hbonds listed from models
                 //extract values
-                const pos1 = l[0].split(".")[1], atm1 = l[3], id1 = l[2], id2 = l[6], pos2 = l[4].split(".")[1], atm2 = l[7], dist = parseFloat(l[10]);
+                const pos1 = l[0].split(".")[1],
+                    atm1 = l[3],
+                    id1 = l[2],
+                    id2 = l[6],
+                    pos2 = l[4].split(".")[1],
+                    atm2 = l[7],
+                    dist = parseFloat(l[10]);
+
                 let pdbinds1 = [pos1, parseInt(id1)];
                 let pdbinds2 = [pos2, parseInt(id2)];
+
                 let hbond = [pdbinds1, pdbinds2];
                 hbonds.push(hbond);
             }
         }
-        if (hbonds.length == 0)
-            notify("H bond file format is unrecongized");
+        if(hbonds.length == 0) notify("H bond file format is unrecongized");
         pdbFileInfo[pdbInfoIndx].hydrogenBonds = hbonds;
-    };
+    }
     reader.readAsText(file);
 }
+
 // associates massfile with last loaded system (only needed for Generic Sphere Systems)
-function readMassFile(reader) {
-    let lines = reader.result.split(/[\n]+/g);
-    let key = {
+function readMassFile(reader){
+    let lines = (reader.result as string).split(/[\n]+/g);
+    let key ={
         indx: [],
         mass: [],
         radius: []
-    };
-    if (parseInt(lines[0]) > 27) { // subtypes 0-27 taken by dna/protein subtypes
+    }
+
+    if(parseInt(lines[0]) > 27){  // subtypes 0-27 taken by dna/protein subtypes
         //remove the header
-        lines = lines.slice(1);
+        lines = lines.slice(1)
         const size = lines.length;
         for (let i = 0; i < size; i++) {
-            let l = lines[i].split(/\s+/);
+            let l = lines[i].split(/\s+/)
             //extract values
-            const p = parseInt(l[0]), mass = parseInt(l[1]), radius = parseFloat(l[2]);
-            if (p > 26) {
-                key.indx.push(p - 27);
+            const p = parseInt(l[0]),
+                mass = parseInt(l[1]),
+                radius = parseFloat(l[2]);
+
+            if(p > 26){
+                key.indx.push(p-27);
                 key.mass.push(mass);
                 key.radius.push(radius);
             }
+
         }
+
         // change all generic sphere radius and mass according to mass file
         let sub, indx, gs;
         systems.forEach(sys => {
             sys.strands.forEach(strand => {
-                if (strand.isGS()) {
+                if(strand.isGS()){
                     let mon = strand.getMonomers();
                     mon.forEach(be => {
-                        sub = parseInt(be.type.substring(2));
+                        sub = parseInt(be.type.substring(2))
                         indx = key.indx.indexOf(sub);
-                        if (indx == -1) {
+                        if(indx == -1){
                             console.log("Subtype " + sub.toString() + " not found in the provided mass file");
-                        }
-                        else {
-                            gs = be;
+                        } else {
+                            gs = <GenericSphere>be;
                             gs.updateSize(key.mass[indx], key.radius[indx]);
                         }
-                    });
+                    })
                 }
-            });
-        });
-    }
-    else {
-        console.log("No GS Masses in file, (no subtype over 27), double check header");
+            })
+        })
+
+
+    } else {
+        console.log("No GS Masses in file, (no subtype over 27), double check header")
     }
 }
-function parseDotBracket(input) {
+
+
+function parseDotBracket(input: string): number[] {
     // Converts a dot-bracket string to a list of paired nucleotides.
-    const output = new Array(input.length).fill(-1);
-    const parenQueue = [];
-    const squareQueue = [];
-    const curlyQueue = [];
+
+    const output: number[] = new Array(input.length).fill(-1);
+    const parenQueue: number[] = [];
+    const squareQueue: number[] = [];
+    const curlyQueue: number[] = [];
+
     for (let i = 0; i < input.trim().length; i++) {
         const c = input[i];
         switch (c) {
@@ -459,14 +654,16 @@ function parseDotBracket(input) {
                 throw new Error(`Encountered invalid character '${c}' in dot bracket`);
         }
     }
+
     return output;
 }
-function readDotBracket(file) {
-    const updateForceHandler = (forces) => {
-        forceHandler.set(forces);
-        render();
-    };
-    file.text().then(txt => {
+
+function readDotBracket(file:File){
+    const updateForceHandler = (forces:Force[])=>{
+        forceHandler.set(forces)
+        render()
+    }
+    file.text().then(txt=>{
         // let's define the input db format as follows:
         // - each line can be a db string or a sequence
         // - they have to alternate and be separated by a newline
@@ -476,85 +673,91 @@ function readDotBracket(file) {
         // - if it finds one, it will create a trap between the bases according to the db string
         // - if the file contains only 1 line it has to be a db string and the trap will be created for the last system for all strands with the same length as the db string
         // - unless there are selected bases, in which case the trap will be created only for the selected bases
+
         // preprocess the file
         // strip spaces and newlines
-        const forces = [];
-        let lines = txt.split("\n").map(s => s.replace(/\s/g, '')).filter(s => s.length > 0);
+        const forces: PairwiseForce[] = []
+        let lines = txt.split("\n").map(s=>s.replace(/\s/g,'')).filter(s=>s.length>0)
+
         // now let's parse the file
-        let file_length = lines.length;
-        let db_strings = [];
-        let sequences = [];
-        for (let i = 0; i < file_length; i++) {
-            if (i % 2 == 0) {
-                db_strings.push(lines[i]);
-            }
-            else {
-                sequences.push(lines[i]);
+        let file_length = lines.length
+        let db_strings = []
+        let sequences = []
+        
+        for (let i = 0; i < file_length; i++){
+            if (i % 2 == 0){
+                db_strings.push(lines[i])
+            } else {
+                sequences.push(lines[i])
             }
         }
+
         // if we have only one line, it has to be a db string
-        if (db_strings.length == 1 && sequences.length == 0) {
-            let db_string = db_strings[0];
-            let pairs = parseDotBracket(db_string);
+        if (db_strings.length == 1 && sequences.length == 0){
+            let db_string = db_strings[0]
+            let pairs = parseDotBracket(db_string)
+
             // we always work with either the last system or the selectedBases
             let to_process;
             // so do we have selected bases ? 
             if (selectedBases.size > 0) {
                 // we do and do only on selectedBases
-                to_process = [[...selectedBases].sort((a, b) => a.id - b.id)];
+                to_process = [[... selectedBases].sort( (a,b)=> a.id - b.id)]
                 if (to_process[0].length != db_string.length)
-                    to_process = []; //make sure we have enough bases selected 
+                    to_process = [] //make sure we have enough bases selected 
             }
             else {
                 // we work with the last system
-                to_process = systems[systems.length - 1].strands.filter(strand => strand.getLength() == db_string.length).map(s => s.getMonomers());
+                to_process = systems[systems.length-1].strands.filter(strand => strand.getLength() == db_string.length).map( s=> s.getMonomers())
             }
-            to_process.forEach(elements => {
-                pairs.forEach((pair, i) => {
+
+            to_process.forEach( elements => {
+                pairs.forEach( (pair, i) => {
                     if (pair != -1) {
                         // if pair
-                        let trap = new MutualTrap();
-                        trap.set(elements[i], elements[pair], .09, 1.2, 1);
-                        forces.push(trap);
+                        let trap = new MutualTrap()
+                        trap.set(elements[i],elements[pair],.09,1.2,1)
+                        forces.push(trap)
                     }
-                });
-            });
-            updateForceHandler(forces);
-            return;
+                })
+            })
+            updateForceHandler(forces)
+            return
         }
+
         // check if the file is valid
-        if (db_strings.length != sequences.length) {
-            notify("Invalid dot bracket file format");
-            return;
+        if (db_strings.length != sequences.length){
+            notify("Invalid dot bracket file format")
+            return
         }
+
         // if we have multiple lines, we have to search the strands for the subsequences
         // and we'll use the first match we find
-        for (let i = 0; i < sequences.length; i++) {
-            let to_process = [];
-            let db_string = db_strings[i];
-            let seq = sequences[i];
-            let pairs = parseDotBracket(db_string);
-            let strands = systems[systems.length - 1].strands.forEach(strand => {
+        
+        for (let i = 0; i < sequences.length; i++){
+            let to_process = []
+            let db_string = db_strings[i]
+            let seq = sequences[i]
+            let pairs = parseDotBracket(db_string)
+            let strands = systems[systems.length-1].strands.forEach( strand => {
                 // check if strand is NucleicAcidStrand
-                if (!(strand instanceof NucleicAcidStrand)) {
-                    return;
-                }
+                if (! (strand instanceof NucleicAcidStrand)){ return }
                 let matches = strand.search(seq);
-                if (matches.length > 0) {
-                    to_process.push(matches[0]);
+                if (matches.length > 0){
+                    to_process.push(matches[0])
                 }
-            });
-            to_process.forEach(elements => {
-                pairs.forEach((pair, i) => {
+            })
+            to_process.forEach( elements => {
+                pairs.forEach( (pair, i) => {
                     if (pair != -1) {
                         // if pair
-                        let trap = new MutualTrap();
-                        trap.set(elements[i], elements[pair], .09, 1.2, 1);
-                        forces.push(trap);
+                        let trap = new MutualTrap()
+                        trap.set(elements[i],elements[pair],.09,1.2,1)
+                        forces.push(trap)
                     }
-                });
-            });
-            updateForceHandler(forces);
-        }
-    });
+                })
+            })
+            updateForceHandler(forces)
+        }  
+    })
 }

--- a/dist/file_handling/order_parameter_selector.js
+++ b/dist/file_handling/order_parameter_selector.js
@@ -58,12 +58,12 @@ let loadHyperSelector = () => {
                 // mode:"dataset", // it is possible to remove the line view from the plot 
                 // intersect:true  // on hover, but i find it to distracting 
             },
-            responsiveAnimationDuration: 0,
+            responsiveAnimationDuration: 0, // animation duration after a resize
             scales: {
                 xAxes: [{ display: true, scaleLabel: { display: true, labelString: 'Time' }, gridLines: { drawOnChartArea: false } }],
                 yAxes: [{ display: true, gridLines: { drawOnChartArea: false } }],
             },
-            spanGaps: true,
+            spanGaps: true, // handle null in the chart data
             annotation: {
                 events: ["click"],
                 annotations: [
@@ -143,7 +143,7 @@ let handleParameterDrop = (files) => {
             else {
                 console.log("adding new axis");
                 myChart.options.scales.yAxes.push({
-                    type: 'linear',
+                    type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
                     display: true,
                     position: 'left',
                     id: `y-axis-id${axis_counter}`,
@@ -159,7 +159,7 @@ let handleParameterDrop = (files) => {
                         labels: labels,
                         datasets: [
                             {
-                                label: parameter_name,
+                                label: parameter_name, //files[0].name.split(".")[0],
                                 data: data,
                                 fill: false,
                                 borderColor: chartColorMap.get(),
@@ -170,7 +170,7 @@ let handleParameterDrop = (files) => {
                 }
                 else {
                     myChart.data.datasets.push({
-                        label: parameter_name,
+                        label: parameter_name, //files[i].name.split(".")[0],
                         data: data,
                         fill: false,
                         borderColor: chartColorMap.get(),

--- a/dist/file_handling/output_file.js
+++ b/dist/file_handling/output_file.js
@@ -128,9 +128,9 @@ function getNewIds(useNew = false) {
     });
     // these subtypes are not implemented in the CG-oxDNA model, just used for a 'relative' subtype that oxDNA will take as input
     let gsSubtypes = {
-        subtypelist: [],
-        masses: [],
-        radii: [],
+        subtypelist: [], // per particle subtype assignment
+        masses: [], //
+        radii: [], //
         subtype: -1
     };
     // Next, generic sphere objects
@@ -477,9 +477,9 @@ function makeUNFOutput(name) {
             let naStrandsSchema = {
                 "id": strand.id,
                 "name": strand.label,
-                "isScaffold": strand.getLength() > 1000 ? true : false,
-                "naType": strand.end5.isDNA() ? "DNA" : "RNA",
-                "color": strand.end5.color ? '#'.concat(strand.end5.color.getHexString()) : '',
+                "isScaffold": strand.getLength() > 1000 ? true : false, //entirely arbitrary, but generally right.
+                "naType": strand.end5.isDNA() ? "DNA" : "RNA", // Nucleotide type is actually pretty poorly defined in oxView, so this is the best I can do
+                "color": strand.end5.color ? '#'.concat(strand.end5.color.getHexString()) : '', // OxView defines colors on a per-nucleotide level while UNF defines it at the strand level.
                 "fivePrimeId": strand.end5.id,
                 "threePrimeId": strand.end3.id,
                 "pdbFileId": 0,
@@ -504,7 +504,7 @@ function makeUNFOutput(name) {
             let aaChainSchema = {
                 "id": strand.id,
                 "chainName": strand.label,
-                "color": strand.end5.color ? '#'.concat(strand.end5.color.getHexString()) : '',
+                "color": strand.end5.color ? '#'.concat(strand.end5.color.getHexString()) : '', // OxView defines colors on a per-nucleotide level while UNF defines it at the strand level.
                 "pdbFileId": 0,
                 "nTerm": strand.end5.id,
                 "cTerm": strand.end3.id,

--- a/dist/file_handling/pdb_worker.js
+++ b/dist/file_handling/pdb_worker.js
@@ -20,48 +20,48 @@ this.onmessage = function (e) {
     postMessage(ret, undefined);
 };
 var backboneColors = [
-    new THREE.Color(0xfdd291),
-    new THREE.Color(0xffb322),
-    new THREE.Color(0x437092),
+    new THREE.Color(0xfdd291), //light yellow
+    new THREE.Color(0xffb322), //goldenrod
+    new THREE.Color(0x437092), //dark blue
     new THREE.Color(0x6ea4cc), //light blue
 ];
 var nucleosideColors = [
-    new THREE.Color(0x4747B8),
-    new THREE.Color(0xFFFF33),
+    new THREE.Color(0x4747B8), //A or K; Royal Blue
+    new THREE.Color(0xFFFF33), //G or C; Medium Yellow
     //C or A
-    new THREE.Color(0x8CFF8C),
+    new THREE.Color(0x8CFF8C), //Medium green
     //T/U or T
-    new THREE.Color(0xFF3333),
+    new THREE.Color(0xFF3333), //Red
     //E
-    new THREE.Color(0x660000),
+    new THREE.Color(0x660000), //Dark Brown
     //S
-    new THREE.Color(0xFF7042),
+    new THREE.Color(0xFF7042), //Medium Orange
     //D
-    new THREE.Color(0xA00042),
+    new THREE.Color(0xA00042), //Dark Rose
     //N
-    new THREE.Color(0xFF7C70),
+    new THREE.Color(0xFF7C70), //Light Salmon
     //Q
-    new THREE.Color(0xFF4C4C),
+    new THREE.Color(0xFF4C4C), //Dark Salmon
     //H
-    new THREE.Color(0x7070FF),
+    new THREE.Color(0x7070FF), //Medium Blue
     //G
-    new THREE.Color(0xEBEBEB),
+    new THREE.Color(0xEBEBEB), // light GREY
     //P
-    new THREE.Color(0x525252),
+    new THREE.Color(0x525252), //Dark Grey
     //R
-    new THREE.Color(0x00007C),
+    new THREE.Color(0x00007C), //Dark Blue
     //V
-    new THREE.Color(0x5E005E),
+    new THREE.Color(0x5E005E), //Dark Purple
     //I
-    new THREE.Color(0x004C00),
+    new THREE.Color(0x004C00), //Dark Green
     //L
-    new THREE.Color(0x455E45),
+    new THREE.Color(0x455E45), //Olive Green
     //M
-    new THREE.Color(0xB8A042),
+    new THREE.Color(0xB8A042), //Light Brown
     //F
-    new THREE.Color(0x534C42),
+    new THREE.Color(0x534C42), //Olive Grey
     //Y
-    new THREE.Color(0x8C704C),
+    new THREE.Color(0x8C704C), //Medium Brown
     //W
     new THREE.Color(0x4F4600), //Olive Brown
 ];

--- a/dist/file_handling/system_readers.js
+++ b/dist/file_handling/system_readers.js
@@ -732,12 +732,13 @@ function readPdbFile(file) {
                     gdata = undefined;
                     gd = undefined;
                     // redraw box so nucleotides will be drawn with backbone connectors
-                    if (box.x < dims[0])
-                        box.x = dims[0] * 1.25;
-                    if (box.y < dims[1])
-                        box.y = dims[1] * 1.25;
-                    if (box.z < dims[2])
-                        box.z = dims[2] * 1.25;
+                    let maxDim = Math.max(...dims);
+                    if (box.x < maxDim)
+                        box.x = maxDim * 1.5;
+                    if (box.y < maxDim)
+                        box.y = maxDim * 1.5;
+                    if (box.z < maxDim)
+                        box.z = maxDim * 1.5;
                     redrawBox();
                     dims = undefined;
                     for (let i = 0; i < pdbtemp[0].length; i++) {

--- a/dist/model/force.js
+++ b/dist/model/force.js
@@ -449,7 +449,7 @@ class ForceHandler {
             let material = new THREE.MeshBasicMaterial({
                 map: texture,
                 side: THREE.DoubleSide,
-                transparent: true,
+                transparent: true, // Enable transparency
                 opacity: 0.5 // Set the desired opacity (0.0 to 1.0)
             });
             let plane = new THREE.Mesh(geometry, material);

--- a/dist/scene/mesh_setup.js
+++ b/dist/scene/mesh_setup.js
@@ -38,49 +38,49 @@ function switchMaterial(material) {
 }
 // Default colors for the backbones
 var backboneColors = [
-    new THREE.Color(0xfdd291),
-    new THREE.Color(0xffb322),
-    new THREE.Color(0x437092),
+    new THREE.Color(0xfdd291), //light yellow
+    new THREE.Color(0xffb322), //goldenrod
+    new THREE.Color(0x437092), //dark blue
     new THREE.Color(0x6ea4cc), //light blue
 ];
 // define nucleoside colors
 var nucleosideColors = [
-    new THREE.Color(0x4747B8),
-    new THREE.Color(0xFFFF33),
+    new THREE.Color(0x4747B8), //A or K; Royal Blue
+    new THREE.Color(0xFFFF33), //G or C; Medium Yellow
     //C or A
-    new THREE.Color(0x8CFF8C),
+    new THREE.Color(0x8CFF8C), //Medium green
     //T/U or T
-    new THREE.Color(0xFF3333),
+    new THREE.Color(0xFF3333), //Red
     //E
-    new THREE.Color(0x660000),
+    new THREE.Color(0x660000), //Dark Brown
     //S
-    new THREE.Color(0xFF7042),
+    new THREE.Color(0xFF7042), //Medium Orange
     //D
-    new THREE.Color(0xA00042),
+    new THREE.Color(0xA00042), //Dark Rose
     //N
-    new THREE.Color(0xFF7C70),
+    new THREE.Color(0xFF7C70), //Light Salmon
     //Q
-    new THREE.Color(0xFF4C4C),
+    new THREE.Color(0xFF4C4C), //Dark Salmon
     //H
-    new THREE.Color(0x7070FF),
+    new THREE.Color(0x7070FF), //Medium Blue
     //G
-    new THREE.Color(0xEBEBEB),
+    new THREE.Color(0xEBEBEB), // light GREY
     //P
-    new THREE.Color(0x525252),
+    new THREE.Color(0x525252), //Dark Grey
     //R
-    new THREE.Color(0x00007C),
+    new THREE.Color(0x00007C), //Dark Blue
     //V
-    new THREE.Color(0x5E005E),
+    new THREE.Color(0x5E005E), //Dark Purple
     //I
-    new THREE.Color(0x004C00),
+    new THREE.Color(0x004C00), //Dark Green
     //L
-    new THREE.Color(0x455E45),
+    new THREE.Color(0x455E45), //Olive Green
     //M
-    new THREE.Color(0xB8A042),
+    new THREE.Color(0xB8A042), //Light Brown
     //F
-    new THREE.Color(0x534C42),
+    new THREE.Color(0x534C42), //Olive Grey
     //Y
-    new THREE.Color(0x8C704C),
+    new THREE.Color(0x8C704C), //Medium Brown
     //W
     new THREE.Color(0x4F4600), //Olive Brown
 ];

--- a/ts/file_handling/aux_readers.ts
+++ b/ts/file_handling/aux_readers.ts
@@ -237,15 +237,78 @@ function parseJson(json:string, system:System) {
                 }
             }
         }
-        else if (data[key][0].length == 6) { //draw arbitrary arrows on the scene
-            for (let entry of data[key]) {
-                const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
-                const vec = new THREE.Vector3(entry[3], entry[4], entry[5]);
-                vec.normalize();
-                const arrowHelper = new THREE.ArrowHelper(vec, pos, 5 * vec.length(), 0x00000);
-                scene.add(arrowHelper);
+        
+        else if (data[key][0].length == 6) { // if each entry is 6 elements long
+
+            const hasCylinder = key.toLowerCase().includes("cylinder"); // if the key of the dictionary includes the substring "cylinder"
+            const hasLine     = key.toLowerCase().includes("line"); // if the key of the dictionary includes the substring "line"
+
+            if (hasCylinder) {// Draw cyclinders. The first three and the last three values in each entry are the coordinates of the start- and end-points of the axis.
+
+                for (let entry of data[key]) {  
+
+                    const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    const radius = 0.8
+
+                    const direction = new THREE.Vector3().subVectors(pos2, pos1);
+                    const length = direction.length();
+
+                    // midpoint for cylinder position
+                    const midpoint = new THREE.Vector3().addVectors(pos1, pos2).multiplyScalar(0.5);
+
+                    const geometry = new THREE.CylinderGeometry(radius, radius, length); 
+                    const material = new THREE.MeshStandardMaterial({color:0xff0000 }); // red
+                    const cylinder = new THREE.Mesh(geometry, material);
+
+                    // align cylinder along direction vector (rotate the cylinder so that its y-axis points from pos1 to pos2)
+                    cylinder.position.copy(midpoint);
+                    cylinder.quaternion.setFromUnitVectors(
+                        new THREE.Vector3(0, 1, 0), // cylinder default points up along Y
+                        direction.clone().normalize()
+                    );
+
+                    scene.add(cylinder);
+
+                    // remove nucleotide and connector for better visualisation
+                    view.setPropertyInScene('nucleoside', system, false);
+                    view.setPropertyInScene('connector', system, false);
+                }
             }
+                
+            else if (hasLine) { // Draw lines. The first three and the last three values of each entry are the coordinates of the start- and end-points of the line.
+                for (let entry of data[key]) {
+
+                    const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+
+                    const geometry = new THREE.BufferGeometry().setFromPoints([pos1, pos2]);
+                    const material = new THREE.LineBasicMaterial({ color: 0xff0000, linewidth: 0.9 });
+                    const line = new THREE.Line(geometry, material); //a red line that starts at pos1 and ends at pos2
+                    scene.add(line);
+
+                    // remove nucleotide and connector for better visualisation
+                    view.setPropertyInScene('nucleoside', system, false);
+                    view.setPropertyInScene('connector', system, false);
+
+                }
+            }
+
+            else { //draw arbitrary arrows on the scene. First three values of each entry are the coordinates for the starting point, the last three make up the vector.
+                for (let entry of data[key]) {
+                    const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const vec = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    vec.normalize();
+                    const arrowHelper = new THREE.ArrowHelper(vec, pos, 5 * vec.length(), 0x00000);
+                    scene.add(arrowHelper);
+                }
+            }
+
+      
         }
+
+
+
         else { //if json and dat files do not match, display error message and set filesLen to 2 (not necessary)
             notify(".json and .top files are not compatible.", "alert");
             return;

--- a/ts/file_handling/aux_readers.ts
+++ b/ts/file_handling/aux_readers.ts
@@ -257,7 +257,7 @@ function parseJson(json:string, system:System) {
                     // midpoint for cylinder position
                     const midpoint = new THREE.Vector3().addVectors(pos1, pos2).multiplyScalar(0.5);
 
-                    const geometry = new THREE.CylinderGeometry(radius, radius, length); 
+                    const geometry = new THREE.CylinderGeometry(radius, radius, length, 64); 
                     const material = new THREE.MeshStandardMaterial({color:0xff0000 }); // red
                     const cylinder = new THREE.Mesh(geometry, material);
 

--- a/ts/file_handling/aux_readers.ts
+++ b/ts/file_handling/aux_readers.ts
@@ -210,6 +210,15 @@ function readForce(forceFile) {
 // Json files can be a lot of things, read them.
 function parseJson(json:string, system:System) {
     const data = JSON.parse(json);
+
+    if (data["_config"]) {
+        const cfg = data["_config"];
+        (cfg.hide || []).forEach(prop => view.setPropertyInScene(prop, system, false));
+        (cfg.show || []).forEach(prop => view.setPropertyInScene(prop, system, true));
+        delete data["_config"];  // don't process it as geometry
+    }
+
+
     for (var key in data) {
         if (data[key].length == system.systemLength()) { //if json and dat files match/same length
             if (typeof (data[key][0]) == "number") { //we assume that scalars denote a new color map
@@ -246,6 +255,7 @@ function parseJson(json:string, system:System) {
         
         else if (data[key][0].length == 6) { // if each entry is 6 elements long
 
+
             const hasCylinder = key.toLowerCase().includes("cylinder"); // if the key of the dictionary includes the substring "cylinder"
             const hasLine     = key.toLowerCase().includes("line"); // if the key of the dictionary includes the substring "line"
 
@@ -275,10 +285,6 @@ function parseJson(json:string, system:System) {
                     );
 
                     scene.add(cylinder);
-
-                    // remove nucleotide and connector for better visualisation
-                    view.setPropertyInScene('nucleoside', system, false);
-                    view.setPropertyInScene('connector', system, false);
                 }
             }
                 
@@ -293,19 +299,29 @@ function parseJson(json:string, system:System) {
                     const line = new THREE.Line(geometry, material); //a red line that starts at pos1 and ends at pos2
                     scene.add(line);
 
-                    // remove nucleotide and connector for better visualisation
-                    view.setPropertyInScene('nucleoside', system, false);
-                    view.setPropertyInScene('connector', system, false);
-
                 }
             }
 
+            // else { //draw arbitrary arrows on the scene. First three values of each entry are the coordinates for the starting point, the last three make up the vector.
+            //     for (let entry of data[key]) {
+            //         const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
+            //         const vec = new THREE.Vector3(entry[3], entry[4], entry[5]);
+            //         vec.normalize();
+            //         const arrowHelper = new THREE.ArrowHelper(vec, pos, 5 * vec.length(), 0x00000);
+            //         scene.add(arrowHelper);
+            //     }
+            // }
+
             else { //draw arbitrary arrows on the scene. First three values of each entry are the coordinates for the starting point, the last three make up the vector.
                 for (let entry of data[key]) {
-                    const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
-                    const vec = new THREE.Vector3(entry[3], entry[4], entry[5]);
-                    vec.normalize();
-                    const arrowHelper = new THREE.ArrowHelper(vec, pos, 5 * vec.length(), 0x00000);
+                    const pos1 = new THREE.Vector3(entry[0], entry[1], entry[2]);
+                    const pos2 = new THREE.Vector3(entry[3], entry[4], entry[5]);
+                    const vec = new THREE.Vector3().subVectors(pos2, pos1);
+
+                    const length = vec.length();  
+                    vec.normalize();  
+
+                    const arrowHelper = new THREE.ArrowHelper(vec, pos1, 0.5*length, 0x000000);
                     scene.add(arrowHelper);
                 }
             }
@@ -314,9 +330,10 @@ function parseJson(json:string, system:System) {
         }
 
         else if (data[key][0].length == 9) { // Draw planes
+
             
-            const hasPlane = key.toLowerCase().includes("plane"); // if the key of the dictionary includes the substring "cylinder"
-            const hasPoint    = key.toLowerCase().includes("point"); // if the key of the dictionary includes the substring "line"
+            const hasPlane = key.toLowerCase().includes("plane"); // if the key of the dictionary includes the substring "plane"
+            const hasPoint    = key.toLowerCase().includes("point"); // if the key of the dictionary includes the substring "point"
 
 
             if (hasPlane) {
@@ -382,6 +399,8 @@ function parseJson(json:string, system:System) {
         }
 
         else if (data[key][0].length == 3) {
+  
+
             for (let entry of data[key]) {  
 
                     const pos = new THREE.Vector3(entry[0], entry[1], entry[2]);
@@ -394,9 +413,6 @@ function parseJson(json:string, system:System) {
 
                     scene.add(s);
 
-                    view.setPropertyInScene('nucleoside', system, false);
-                    view.setPropertyInScene('connector', system, false);
-        
                 }
         }
         else { //if json and dat files do not match, display error message and set filesLen to 2 (not necessary)

--- a/ts/file_handling/system_readers.ts
+++ b/ts/file_handling/system_readers.ts
@@ -853,9 +853,10 @@ function readPdbFile(file) {
                     gd = undefined;
 
                     // redraw box so nucleotides will be drawn with backbone connectors
-                    if(box.x < dims[0]) box.x = dims[0]*1.25;
-                    if(box.y < dims[1]) box.y = dims[1]*1.25;
-                    if(box.z < dims[2]) box.z = dims[2]*1.25;
+                    let maxDim = Math.max(...dims);
+                    if(box.x < maxDim) box.x = maxDim*1.5;
+                    if(box.y < maxDim) box.y = maxDim*1.5;
+                    if(box.z < maxDim) box.z = maxDim*1.5;
                     redrawBox();
 
                     dims = undefined;


### PR DESCRIPTION
These new additions include cylinder and line rendering options for the specific case when the entries of the overlay dictionary (the json file) are 6 elements long. 

Before, 6-element long entries would draw arrows by default (whereby the first 3 values are the coordinates for the starting point, and the last 3 represent the vector). 
Now, if the dictionary key (the overlay parameter name) includes the substring "cylinder" or "line", these are displayed instead. The first three and the last three values are now the start and end points of the cylinder axis/of the line. 
If these substrings are not present, it defaults to the arrows as previously. 

The display of the cylinders/lines was originally meant for better visualisation of helical axes. For that reason when these options are chosen, the nucleosides and connector are automatically hidden (leaving only the backbone), for a clearer view.
