### PR TITLE
Add support for strand-level coloring in the oxView topology reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ You can also watch the tutorial: [Creating oxDNA videos in oxView](https://www.y
 **PNG/JPEG**: Will download a .zip file with every frame saved as a image of the specified type.  Can be converted to video formats using other software such as ffmpeg or ImageJ.
 
 ### Input Format
-The topology and trajectory/configuration have to be in oxDNA format. You can convert from other formats (such as PDB, LAMMPS, caDNAno) using TacoxDNA converter: http://tacoxdna.sissa.it/
+The topology and trajectory/configuration have to be in oxDNA format. You can convert from other formats (such as PDB, LAMMPS, caDNAno) using TacoxDNA converter: http://tacoxdna.sissa.it/.
+
 Note that in the new topology format, a color for each strand can be defined via hex code.
 
 ---

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can also watch the tutorial: [Creating oxDNA videos in oxView](https://www.y
 
 ### Input Format
 The topology and trajectory/configuration have to be in oxDNA format. You can convert from other formats (such as PDB, LAMMPS, caDNAno) using TacoxDNA converter: http://tacoxdna.sissa.it/
+Note that in the new topology format, a color for each strand can be defined via hex code.
 
 ---
 

--- a/ts/file_handling/output_file.ts
+++ b/ts/file_handling/output_file.ts
@@ -293,7 +293,7 @@ function makeTopFile(name:string, newElementIDs:Map<BasicElement, number>, newSt
 
     function makeTopFileNew(name){
         const top: string[] = []; // string of contents of .top file
-        let default_props = ['id', 'type', 'circular']
+        let default_props = ['id', 'type', 'circular', 'color']
 
         let firstLine:string[] = [counts['totParticles'].toString(), counts['totStrands'].toString()];
 
@@ -308,8 +308,21 @@ function makeTopFile(name:string, newElementIDs:Map<BasicElement, number>, newSt
         top.push(firstLine.join(" "));
 
         newStrandIDs.forEach((_id, s) => {
-            let line = [s.getSequence(), "id="+_id.toString(), "type="+s.kwdata['type'], "circular="+s.isCircular(), s.getKwdataString(default_props)]
-            top.push(line.join(" "))
+            // save user color changes in the exported topology file
+            let colorStr = '';
+            let e = s.end5 || s.end3;
+            if (e) {
+                try {
+                    let sys = e.getSystem();
+                    let idx = e.sid * 3;
+                    let bbColor = new THREE.Color(sys.bbColors[idx], sys.bbColors[idx+1], sys.bbColors[idx+2]);
+                    colorStr = 'color=#' + bbColor.getHexString();
+                } catch(err) {
+                    console.warn('Could not read color for strand', _id, err);
+                }
+            }
+            let line = [s.getSequence(), "id="+_id.toString(), "type="+s.kwdata['type'], "circular="+s.isCircular(), colorStr, s.getKwdataString(default_props)]
+            top.push(line.join(" ").trim())
         })
         
         top.push('') // topology has to end in an empty line

--- a/ts/file_handling/system_readers.ts
+++ b/ts/file_handling/system_readers.ts
@@ -149,6 +149,14 @@ function parseTop(s: string) {
 
             new_strand.end3 = nuc;
 
+            // set the strand color if specified
+            if (kwdata['color']) {
+                let strandColor = new THREE.Color(kwdata['color']);
+                new_strand.forEach((elem) => {
+                    elem.color = strandColor.clone();
+                });
+            }
+
             if (kwdata["circular"]) {
                 new_strand.end3.n3 = new_strand.end5;
                 new_strand.end5.n5 = new_strand.end3;
@@ -275,6 +283,13 @@ function parseTop(s: string) {
     system.initInstances(system.systemLength())
     system.fillDefaultColors();
     addSystemToScene(system);
+
+    // if any colors are specified, switch to custom color mode
+    let hasTopologyColors = system.strands.some(s => s.kwdata && s.kwdata['color']);
+    if (hasTopologyColors) {
+        view.coloringMode.set("Custom");
+    }
+
     return system
 }
 


### PR DESCRIPTION
The new-style oxDNA topology allows for arbitrary key-value pairs to be defined at the strand level. Update the oxView file reader to allow colors to be defined in the .top file, making (s)Cadnano-style coloring carry through all stages of simulation without additional auxiliary files. Use the "color" keyword with a hex code value to set the color of a strand. 